### PR TITLE
Better describe multiple JS Hook initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ const hooks = {
     MyHook: {
         // ...
     },
-    ...live_select
+    LiveSelect: live_select.LiveSelect
 }
 let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}, hooks})
 ```


### PR DESCRIPTION
With multiple JS Hooks for LiveSocket to initialiize, it is necessary to add the LiveSelect hook as `LiveSelect: live_select.LiveSelect` otherwise it fails to initialize properly resulting in `live_select_change` not being emitted properly.