### PR TITLE
erlang 25.3

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 elixir 1.14.0-otp-25
+erlang 25.3


### PR DESCRIPTION
## Short explanation of PR
updated erlang to 25.3 so that asdf installs both erlang and elixir to correct versions. 

## Issue: 
In my use case, i had elixir setup as in `.tool-versions` but erlang was on 24.3.  so got errors. 

## Solution
This PR would fix default erlang version.