### PR TITLE
Allow pattern matching on emptied field

### DIFF
--- a/assets/js/live_select.js
+++ b/assets/js/live_select.js
@@ -78,7 +78,7 @@ export default {
             this.textInput().value = value
         },
         inputEvent(selection, mode) {
-            const selector = mode === "single" ? "input[class=single-mode]" : (selection.length === 0 ? "input[name=live_select_empty_selection]" : "input[type=hidden]")
+            const selector = mode === "single" ? "input[class=single-mode]" : (selection.length === 0 ? "input[data-live-select-empty]" : "input[type=hidden]")
             this.el.querySelector(selector).dispatchEvent(new Event('input', {bubbles: true}))
         },
         mounted() {

--- a/lib/live_select/component.html.heex
+++ b/lib/live_select/component.html.heex
@@ -62,8 +62,8 @@
     <%= if Enum.empty?(@selection) do %>
       <input
         type="hidden"
-        name={"live_select_empty_selection_#{@field.id}"}
-        id={"live_select_empty_selection_#{@myself}"}
+        name={"#{@field.form.name}[#{@field.field}_empty_selection]"}
+        id={"#{@field.id}_empty_selection"}
         disabled={@disabled}
         data-live-select-empty
       />

--- a/lib/live_select/component.html.heex
+++ b/lib/live_select/component.html.heex
@@ -62,10 +62,9 @@
     <%= if Enum.empty?(@selection) do %>
       <input
         type="hidden"
-        name="live_select_empty_selection"
+        name={"live_select_empty_selection_#{@myself}"}
         id={"live_select_empty_selection_#{@myself}"}
         disabled={@disabled}
-        value={@field.id}
       />
     <% end %>
     <%= for {value, idx} <- values(@selection) |> Enum.with_index() do %>

--- a/lib/live_select/component.html.heex
+++ b/lib/live_select/component.html.heex
@@ -65,6 +65,7 @@
         name="live_select_empty_selection"
         id={"live_select_empty_selection_#{@myself}"}
         disabled={@disabled}
+        value={@field.id}
       />
     <% end %>
     <%= for {value, idx} <- values(@selection) |> Enum.with_index() do %>

--- a/lib/live_select/component.html.heex
+++ b/lib/live_select/component.html.heex
@@ -62,9 +62,10 @@
     <%= if Enum.empty?(@selection) do %>
       <input
         type="hidden"
-        name={"live_select_empty_selection_#{@myself}"}
+        name={"live_select_empty_selection_#{@field.id}"}
         id={"live_select_empty_selection_#{@myself}"}
         disabled={@disabled}
+        data-live-select-empty
       />
     <% end %>
     <%= for {value, idx} <- values(@selection) |> Enum.with_index() do %>


### PR DESCRIPTION
With 2 LiveSelects with `:tags` mode in a page this helps figuring out which one was emptied when the change event triggers.

Before:
```
%{"_target" => ["live_select_empty_selection"], "live_select_empty_selection" => ""}
```

After:
```
%{"_target" => ["live_select_empty_selection_dummy_field_name"], "dummy_field_name" => ""}
```