### PR TITLE
Add sticky options

### DIFF
--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -85,14 +85,10 @@ defmodule LiveSelect do
 
   In some scenarios it may be desired to have unremovable options after they're selected when the user selects an option or when they are set programatically.
 
-  For such cases you can pass `sticky: true` with a map or add a third value to tuple options.
+  For such cases you can add `sticky: true` to the options.
 
   ```
   [%{label: "New York", value: "NY", sticky: true}]
-  ```
-  or
-  ```
-  [{"New York", "NY", true}]
   ```
 
   ## Slots

--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -41,14 +41,12 @@ defmodule LiveSelect do
   Each option will be assigned a label, which will be shown in the dropdown, and a value, which will be the value of the
   LiveSelect input when the option is selected.
 
-  In `:tags` mode, an extra `sticky` option with a boolean value can be used to not let the option to be removed after it is selected.
-
   `options` can be any enumeration of the following elements:
 
   * _atoms, strings or numbers_: In this case, each element will be both label and value for the option
-  * _tuples_: `{label, value}` corresponding to label and value for the option or `{label, value, sticky}` when `sticky` is a boolean value
-  * _maps_: `%{label: label, value: value}` or `%{value: value}` or `%{label: label, value: value, sticky: sticky}`
-  * _keywords_: `[label: label, value: value]` or `[value: value]` or `[label: label, value: value, sticky: sticky]`
+  * _tuples_: `{label, value}` corresponding to label and value for the option
+  * _maps_: `%{label: label, value: value}` or `%{value: value}` 
+  * _keywords_: `[label: label, value: value]` or `[value: value]`
 
   In the case of maps and keywords, if only `value` is specified, it will be used as both value and label for the option.
 
@@ -82,7 +80,21 @@ defmodule LiveSelect do
   ```
 
   will result in "New York" and "Barcelona" being used for the options in the dropdown, while "NY" and "BCN" will be used for the tags.
-    
+
+  ## Sticky options
+
+  In some scenarios it may be desired to have unremovable options after they're selected when the user selects an option or when they are set programatically.
+
+  For such cases you can pass `sticky: true` with a map or add a third value to tuple options.
+
+  ```
+  [%{label: "New York", value: "NY", sticky: true}]
+  ```
+  or
+  ```
+  [{"New York", "NY", true}]
+  ```
+
   ## Slots
     
   You can control how your options and tags are rendered by using the `:option` and `:tag` slots.

--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -40,15 +40,17 @@ defmodule LiveSelect do
   You can pass or update the list of options the user can choose from with the `options` assign.
   Each option will be assigned a label, which will be shown in the dropdown, and a value, which will be the value of the
   LiveSelect input when the option is selected.
-   
+
+  In `:tags` mode, an extra `sticky` option with a boolean value can be used to not let the option to be removed after it is selected.
+
   `options` can be any enumeration of the following elements:
 
   * _atoms, strings or numbers_: In this case, each element will be both label and value for the option
-  * _tuples_: `{label, value}` corresponding to label and value for the option
-  * _maps_: `%{label: label, value: value}` or `%{value: value}` 
-  * _keywords_: `[label: label, value: value]` or `[value: value]`
+  * _tuples_: `{label, value}` corresponding to label and value for the option or `{label, value, sticky}` when `sticky` is a boolean value
+  * _maps_: `%{label: label, value: value}` or `%{value: value}` or `%{label: label, value: value, sticky: sticky}`
+  * _keywords_: `[label: label, value: value]` or `[value: value]` or `[label: label, value: value, sticky: sticky]`
 
-  In the case of maps and keywords, if only `value` is specified, it will be used as both value and label for the option. 
+  In the case of maps and keywords, if only `value` is specified, it will be used as both value and label for the option.
 
   Because you can pass a list of tuples, you can use maps and keyword lists to pass the list of options, for example:
 
@@ -59,7 +61,7 @@ defmodule LiveSelect do
   Will result in 3 options with labels `:Red`, `:Yellow`, `:Green` and values 1, 2, and 3.
 
   Note that the option values, if they are not strings, will be JSON-encoded. Your LiveView will receive this JSON-encoded version in the `phx-change` and `phx-submit` events.
-    
+
   ## Styling 
     
   `LiveSelect` supports 3 styling modes:

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -497,9 +497,6 @@ defmodule LiveSelect.Component do
       {label, value} ->
         {:ok, %{label: label, value: value}}
 
-      {label, value, sticky} ->
-        {:ok, %{label: label, value: value, sticky: sticky}}
-
       option when is_binary(option) or is_atom(option) or is_number(option) ->
         {:ok, %{label: option, value: option}}
 

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -485,20 +485,23 @@ defmodule LiveSelect.Component do
         {:ok, nil}
 
       %{key: key, value: _value} = option ->
-        {:ok, Map.put_new(option, :label, key)}
+        {:ok, Map.merge(%{label: key, sticky: false}, option)}
 
       %{value: value} = option ->
-        {:ok, Map.put_new(option, :label, value)}
+        {:ok, Map.merge(%{label: value, sticky: false}, option)}
 
       option when is_list(option) ->
         Map.new(option)
         |> normalize()
 
       {label, value} ->
-        {:ok, %{label: label, value: value}}
+        {:ok, %{label: label, value: value, sticky: false}}
+
+      {label, value, sticky} ->
+        {:ok, %{label: label, value: value, sticky: sticky}}
 
       option when is_binary(option) or is_atom(option) or is_number(option) ->
-        {:ok, %{label: option, value: option}}
+        {:ok, %{label: option, value: option, sticky: false}}
 
       _ ->
         :error
@@ -615,7 +618,7 @@ defmodule LiveSelect.Component do
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 20 20"
       fill="currentColor"
-      class="w-5 h-5 @class"
+      class={["w-5 h-5", @class]}
     >
       <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
     </svg>

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -485,23 +485,23 @@ defmodule LiveSelect.Component do
         {:ok, nil}
 
       %{key: key, value: _value} = option ->
-        {:ok, Map.merge(%{label: key, sticky: false}, option)}
+        {:ok, Map.put_new(option, :label, key)}
 
       %{value: value} = option ->
-        {:ok, Map.merge(%{label: value, sticky: false}, option)}
+        {:ok, Map.put_new(option, :label, value)}
 
       option when is_list(option) ->
         Map.new(option)
         |> normalize()
 
       {label, value} ->
-        {:ok, %{label: label, value: value, sticky: false}}
+        {:ok, %{label: label, value: value}}
 
       {label, value, sticky} ->
         {:ok, %{label: label, value: value, sticky: sticky}}
 
       option when is_binary(option) or is_atom(option) or is_number(option) ->
-        {:ok, %{label: option, value: option, sticky: false}}
+        {:ok, %{label: option, value: option}}
 
       _ ->
         :error

--- a/lib/live_select/component.html.heex
+++ b/lib/live_select/component.html.heex
@@ -19,7 +19,7 @@
           <% else %>
             <%= render_slot(@tag, option) %>
           <% end %>
-          <button type="button" data-idx={idx}>
+          <button :if={!option[:sticky]} type="button" data-idx={idx}>
             <.x class="cursor-pointer" />
           </button>
         </div>

--- a/test/live_select_tags_test.exs
+++ b/test/live_select_tags_test.exs
@@ -245,10 +245,29 @@ defmodule LiveSelectTagsTest do
     assert_selected_multiple(live, ~w(B A))
   end
 
-  test "can set an option as sticky so it can't be removed", %{live: live} do
+  test "can set an option as sticky so it can't be removed with map options", %{live: live} do
     stub_options([
       %{tag_label: "R", value: "Rome", sticky: true},
       %{tag_label: "NY", value: "New York"}
+    ])
+
+    type(live, "ABC")
+
+    select_nth_option(live, 1)
+
+    type(live, "ABC")
+
+    select_nth_option(live, 2)
+
+    refute_option_removeable(live, 1)
+
+    assert_option_removeable(live, 2)
+  end
+
+  test "can set an option as sticky so it can't be removed with tuple options", %{live: live} do
+    stub_options([
+      {"R", "Rome", true},
+      {"NY", "New York"}
     ])
 
     type(live, "ABC")
@@ -276,8 +295,8 @@ defmodule LiveSelectTagsTest do
     select_nth_option(live, 2)
 
     assert_selected_multiple(live, [
-      %{label: "Rome", value: "Rome", tag_label: "R", sticky: false},
-      %{label: "New York", value: "New York", tag_label: "NY", sticky: false}
+      %{label: "Rome", value: "Rome", tag_label: "R"},
+      %{label: "New York", value: "New York", tag_label: "NY"}
     ])
   end
 
@@ -293,8 +312,8 @@ defmodule LiveSelectTagsTest do
     select_nth_option(live, 2)
 
     assert_selected_multiple(live, [
-      %{label: "Rome", value: "Rome", tag_label: "R", sticky: false},
-      %{label: "New York", value: "New York", tag_label: "NY", sticky: false}
+      %{label: "Rome", value: "Rome", tag_label: "R"},
+      %{label: "New York", value: "New York", tag_label: "NY"}
     ])
   end
 
@@ -365,8 +384,8 @@ defmodule LiveSelectTagsTest do
     send_update(live, value: [3, 5], options: [{"C", 3}, {"D", 4}, {"E", 5}])
 
     assert_selected_multiple(live, [
-      %{label: "C", value: 3, sticky: false},
-      %{label: "E", value: 5, sticky: false}
+      %{label: "C", value: 3},
+      %{label: "E", value: 5}
     ])
   end
 

--- a/test/live_select_tags_test.exs
+++ b/test/live_select_tags_test.exs
@@ -245,6 +245,25 @@ defmodule LiveSelectTagsTest do
     assert_selected_multiple(live, ~w(B A))
   end
 
+  test "can set an option as sticky so it can't be removed", %{live: live} do
+    stub_options([
+      %{tag_label: "R", value: "Rome", sticky: true},
+      %{tag_label: "NY", value: "New York"}
+    ])
+
+    type(live, "ABC")
+
+    select_nth_option(live, 1)
+
+    type(live, "ABC")
+
+    select_nth_option(live, 2)
+
+    refute_option_removeable(live, 1)
+
+    assert_option_removeable(live, 2)
+  end
+
   test "can specify alternative labels for tags using maps", %{live: live} do
     stub_options([%{tag_label: "R", value: "Rome"}, %{tag_label: "NY", value: "New York"}])
 
@@ -257,8 +276,8 @@ defmodule LiveSelectTagsTest do
     select_nth_option(live, 2)
 
     assert_selected_multiple(live, [
-      %{label: "Rome", value: "Rome", tag_label: "R"},
-      %{label: "New York", value: "New York", tag_label: "NY"}
+      %{label: "Rome", value: "Rome", tag_label: "R", sticky: false},
+      %{label: "New York", value: "New York", tag_label: "NY", sticky: false}
     ])
   end
 
@@ -274,8 +293,8 @@ defmodule LiveSelectTagsTest do
     select_nth_option(live, 2)
 
     assert_selected_multiple(live, [
-      %{label: "Rome", value: "Rome", tag_label: "R"},
-      %{label: "New York", value: "New York", tag_label: "NY"}
+      %{label: "Rome", value: "Rome", tag_label: "R", sticky: false},
+      %{label: "New York", value: "New York", tag_label: "NY", sticky: false}
     ])
   end
 
@@ -345,7 +364,10 @@ defmodule LiveSelectTagsTest do
 
     send_update(live, value: [3, 5], options: [{"C", 3}, {"D", 4}, {"E", 5}])
 
-    assert_selected_multiple(live, [%{label: "C", value: 3}, %{label: "E", value: 5}])
+    assert_selected_multiple(live, [
+      %{label: "C", value: 3, sticky: false},
+      %{label: "E", value: 5, sticky: false}
+    ])
   end
 
   defp select_and_open_dropdown(live, pos) do

--- a/test/live_select_tags_test.exs
+++ b/test/live_select_tags_test.exs
@@ -245,29 +245,10 @@ defmodule LiveSelectTagsTest do
     assert_selected_multiple(live, ~w(B A))
   end
 
-  test "can set an option as sticky so it can't be removed with map options", %{live: live} do
+  test "can set an option as sticky so it can't be removed", %{live: live} do
     stub_options([
       %{tag_label: "R", value: "Rome", sticky: true},
       %{tag_label: "NY", value: "New York"}
-    ])
-
-    type(live, "ABC")
-
-    select_nth_option(live, 1)
-
-    type(live, "ABC")
-
-    select_nth_option(live, 2)
-
-    refute_option_removeable(live, 1)
-
-    assert_option_removeable(live, 2)
-  end
-
-  test "can set an option as sticky so it can't be removed with tuple options", %{live: live} do
-    stub_options([
-      {"R", "Rome", true},
-      {"NY", "New York"}
     ])
 
     type(live, "ABC")

--- a/test/live_select_tags_test.exs
+++ b/test/live_select_tags_test.exs
@@ -383,10 +383,7 @@ defmodule LiveSelectTagsTest do
 
     send_update(live, value: [3, 5], options: [{"C", 3}, {"D", 4}, {"E", 5}])
 
-    assert_selected_multiple(live, [
-      %{label: "C", value: 3},
-      %{label: "E", value: 5}
-    ])
+    assert_selected_multiple(live, [%{label: "C", value: 3}, %{label: "E", value: 5}])
   end
 
   defp select_and_open_dropdown(live, pos) do

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -295,7 +295,7 @@ defmodule LiveSelect.TestHelpers do
   def normalize_selection(selection) do
     for element <- selection do
       if is_binary(element) || is_integer(element) || is_atom(element) do
-        %{value: element, label: element, sticky: false}
+        %{value: element, label: element}
       else
         element
       end
@@ -401,10 +401,14 @@ defmodule LiveSelect.TestHelpers do
   def assert_option_removeable(live, n) do
     selector = "#{@selectors[:tags_container]} button[data-idx=#{n - 1}]"
 
-    has_element?(live, selector)
+    assert has_element?(live, selector)
   end
 
-  def refute_option_removeable(live, n), do: !assert_option_removeable(live, n)
+  def refute_option_removeable(live, n) do
+    selector = "#{@selectors[:tags_container]} button[data-idx=#{n - 1}]"
+
+    refute has_element?(live, selector)
+  end
 
   def navigate(live, n, dir, opts \\ []) do
     key =

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -295,7 +295,7 @@ defmodule LiveSelect.TestHelpers do
   def normalize_selection(selection) do
     for element <- selection do
       if is_binary(element) || is_integer(element) || is_atom(element) do
-        %{value: element, label: element}
+        %{value: element, label: element, sticky: false}
       else
         element
       end
@@ -397,6 +397,14 @@ defmodule LiveSelect.TestHelpers do
       input_event: ^input_event
     })
   end
+
+  def assert_option_removeable(live, n) do
+    selector = "#{@selectors[:tags_container]} button[data-idx=#{n - 1}]"
+
+    has_element?(live, selector)
+  end
+
+  def refute_option_removeable(live, n), do: !assert_option_removeable(live, n)
 
   def navigate(live, n, dir, opts \\ []) do
     key =


### PR DESCRIPTION
Hi again!

This adds the ability to make options unremovable after they're selected.

In our app we share a form with 2 LiveViews and use LiveSelect to handle a nested association, in one of the pages we pre-set a default option that can't be removed but the user is still allowed to add/remove other options.

I've tried to follow your library standards and any feedback to improve my contribution is welcome.

Thanks!