### PR TITLE
Fix example in cheatsheet.cheatmd

### DIFF
--- a/cheatsheet.cheatmd
+++ b/cheatsheet.cheatmd
@@ -7,7 +7,7 @@ def live_select(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
   assigns =
     assigns
     |> assign(:errors, Enum.map(field.errors, &translate_error(&1)))
-    |> assign(:live_select_opts, assigns_to_attributes(assigns, [:errors, :label, :size]))
+    |> assign(:live_select_opts, assigns_to_attributes(assigns, [:errors, :label]))
   
   ~H"""
   <div phx-feedback-for={@field.name}>

--- a/cheatsheet.cheatmd
+++ b/cheatsheet.cheatmd
@@ -4,9 +4,10 @@
 
 ```elixir
 def live_select(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
-  assigns = assign(assigns, :errors, Enum.map(field.errors, &translate_error(&1)))
-  
-  live_select_opts = assigns_to_attributes(assigns, [:errors, :label])
+  assigns =
+    assigns
+    |> assign(:errors, Enum.map(field.errors, &translate_error(&1)))
+    |> assign(:live_select_opts, assigns_to_attributes(assigns, [:errors, :label, :size]))
   
   ~H"""
   <div phx-feedback-for={@field.name}>
@@ -20,7 +21,7 @@ def live_select(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
         "border-zinc-300 focus:border-zinc-400 focus:ring-zinc-800/5",
         @errors != [] && "border-rose-400 focus:border-rose-400 focus:ring-rose-400/10"
       ]}
-      {live_select_opts}
+      {@live_select_opts}
     />
   
     <.error :for={msg <- @errors}><%= msg %></.error>


### PR DESCRIPTION
The Phoenix Core Component example in cheatsheet.cheatmd generates warning. This fixes it.