### PR TITLE
replaced input[class=single-mode] with input.single-mode

### DIFF
--- a/assets/js/live_select.js
+++ b/assets/js/live_select.js
@@ -78,7 +78,7 @@ export default {
             this.textInput().value = value
         },
         inputEvent(selection, mode) {
-            const selector = mode === "single" ? "input[class=single-mode]" : (selection.length === 0 ? "input[data-live-select-empty]" : "input[type=hidden]")
+            const selector = mode === "single" ? "input.single-mode" : (selection.length === 0 ? "input[data-live-select-empty]" : "input[type=hidden]")
             this.el.querySelector(selector).dispatchEvent(new Event('input', {bubbles: true}))
         },
         mounted() {


### PR DESCRIPTION
Hello, I am experiencing this very weird error since some time now using live_select

```
live_select.min.js:24 Uncaught TypeError: Cannot read properties of null (reading 'dispatchEvent')
    at ViewHook.inputEvent (live_select.min.js:24:40)
    at live_select.min.js:24:526
    at callbackRef (view_hook.js:43:65)
    at Object.dispatchEvent (dom.js:335:12)
    at LiveSocket.dispatchEvent (live_socket.js:737:9)
    at live_socket.js:741:47
    at Array.forEach (<anonymous>)
    at LiveSocket.dispatchEvents (live_socket.js:741:12)
    at View.update (view.js:527:21)
    at view.js:600:68
```

After some debugging I found that this line https://github.com/maxmarcon/live_select/blob/main/assets/js/live_select.js#L81 don't return the input node (when single-mode is selected). 
But if I replace `input[class=single-mode]` with `input.single-mode` the issue is solved. I'm aware that using the attr syntax with classes is risky (eg. it does work only if the order of the classes differs and it's less performant than using class-based selectors...
