### PR TITLE
fix: form update should not revert options

### DIFF
--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -83,7 +83,8 @@ defmodule LiveSelect.Component do
         active_option: -1,
         hide_dropdown: true,
         awaiting_update: true,
-        saved_selection: nil
+        saved_selection: nil,
+        previous_options: nil
       )
 
     {:ok, socket}
@@ -106,6 +107,17 @@ defmodule LiveSelect.Component do
 
   @impl true
   def update(assigns, socket) do
+    %{previous_options: previous_options} = socket.assigns
+    is_rendering_from_scratch = Map.has_key?(assigns, :field)
+
+    assigns = if previous_options && is_rendering_from_scratch do
+      Map.put(assigns, :options, previous_options)
+    else
+      assigns
+    end
+
+    assigns = Map.put(assigns, :previous_options, assigns.options)
+
     validate_assigns!(assigns)
 
     socket =
@@ -303,6 +315,7 @@ defmodule LiveSelect.Component do
           :tag,
           :clear,
           :hide_dropdown,
+          :previous_options,
           # for backwards compatibility
           :form
         ]


### PR DESCRIPTION
hey again.

so i found an annoying issue where the live_select is part of a form and when the user changes value X, then value Y gets auto updated through handle_event in the form_component, but since the form is updated the live_select is also reevaluated. this means the options are returned to whatever is default.

so this option will detect if it's an update or is this a re-evaluation coming from the parent. and I basically just disable the option change if it's not a legit option.

i view this PR as a draft as the better solution would be to have two update() functions, one for first-render and the other for updates. but I thought i'd submit a working solution first and see what you think of it (and also I'm not  100% sure what the update function currently does and which parts are needed in which case).

so anyway - what do you think of this? what am I misunderstanding?