### PR TITLE
fix: Always update selection on a re-render

### DIFF
--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -83,7 +83,8 @@ defmodule LiveSelect.Component do
         active_option: -1,
         hide_dropdown: true,
         awaiting_update: true,
-        saved_selection: nil
+        saved_selection: nil,
+        selection: nil
       )
 
     {:ok, socket}
@@ -131,8 +132,8 @@ defmodule LiveSelect.Component do
       end)
       |> update(:options, &normalize_options/1)
       |> assign(:text_input_field, String.to_atom("#{socket.assigns.field.field}_text_input"))
-      |> assign_new(:selection, fn
-        %{field: field, options: options, mode: mode} ->
+      |> update(:selection, fn
+        _, %{field: field, options: options, mode: mode} ->
           set_selection(field.value, options, mode)
       end)
 


### PR DESCRIPTION
This will allow it to be set on an auto-recover of the parent form

Previously, the selection would be set to `[]` on mount, and then an auto-recover would change the form field (updating the field value), but not update the live_select selection, because it was already set.

This couldn't be avoided by setting the `value` for the live_select component because that triggers a client event, which seems to invoke an infinite loop between the `phx-blur` and `phx-change` events defined for the component, when invoked after an auto-recover.

---

This is my first time using the library so there may be a better way to approach this (that doesn't break a bunch of the tests!), but this change seems to work for our use case...