### PR TITLE
Option update callback

### DIFF
--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -336,6 +336,8 @@ defmodule LiveSelect do
     doc:
       "Event to emit when the text input receives focus. The component id will be sent in the event's params"
 
+  attr :on_option_update, :any, doc: "Callback to be invoked when an option is clicked or removed"
+
   @styling_options ~w(active_option_class available_option_class clear_button_class container_class container_extra_class dropdown_class dropdown_extra_class option_class option_extra_class text_input_class text_input_extra_class text_input_selected_class selected_option_class tag_class tag_extra_class tags_container_class tags_container_extra_class)a
 
   for attr_name <- @styling_options do

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -298,7 +298,8 @@ defmodule LiveSelect.Component do
     idx = String.to_integer(idx)
 
     if socket.assigns.on_option_update,
-      do: socket.assigns.on_option_update.(%{option_remove: Enum.at(socket.assigns.selection, idx)})
+      do:
+        socket.assigns.on_option_update.(%{option_remove: Enum.at(socket.assigns.selection, idx)})
 
     {:noreply, unselect(socket, idx)}
   end

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -38,7 +38,8 @@ defmodule LiveSelect.Component do
     text_input_extra_class: nil,
     text_input_selected_class: nil,
     update_min_len: 1,
-    value: nil
+    value: nil,
+    on_option_update: nil
   ]
 
   @styles [
@@ -282,14 +283,24 @@ defmodule LiveSelect.Component do
 
   @impl true
   def handle_event("option_click", %{"idx" => idx}, socket) do
-    socket = assign(socket, :active_option, String.to_integer(idx))
+    idx = String.to_integer(idx)
+
+    if socket.assigns.on_option_update,
+      do: socket.assigns.on_option_update.(%{option_click: Enum.at(socket.assigns.options, idx)})
+
+    socket = assign(socket, :active_option, idx)
 
     {:noreply, maybe_select(socket)}
   end
 
   @impl true
   def handle_event("option_remove", %{"idx" => idx}, socket) do
-    {:noreply, unselect(socket, String.to_integer(idx))}
+    idx = String.to_integer(idx)
+
+    if socket.assigns.on_option_update,
+      do: socket.assigns.on_option_update.(%{option_remove: Enum.at(socket.assigns.selection, idx)})
+
+    {:noreply, unselect(socket, idx)}
   end
 
   @impl true


### PR DESCRIPTION
Define a callback to send updated options to the LiveView or Component where LiveSelect component is initialized.