### PR TITLE
Adds `:append` option to add values to the selection in `:tags` mode.

### DIFF
--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -129,9 +129,22 @@ defmodule LiveSelect do
 
   `new_selection` must be a single element in `:single` mode, a list in `:tags` mode. If it's `nil`, the selection will be cleared.  
   After updating the selection, `LiveSelect` will trigger a change event in the form.  
+  `new_selection` must be a single element in `:single` mode, a list in `:tags` mode. If it's `nil`, the selection will be cleared.
+  After updating the selection, `LiveSelect` will trigger a change event in the form.
 
   To set a custom id for the component to use with `Phoenix.LiveView.send_update/3`, you can pass the `id` assign to `live_select/1`.
 
+  ### Appending to the selection in `:tags` mode
+
+  When you want to append to the current selection, you can use the `:append` key in the `send_update` call:
+
+  ```
+  send_update(LiveSelect.Component, id: live_select_id, append: values_to_append)
+  ```
+
+  `values_to_append` can be a single element or a list to append to the current selection. If the value to append already exists in the selection, it will be ignored.
+
+  Note: This does not work in `:single` mode. Use `:value` instead to replace the selection.
 
   ## Examples
 

--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -127,8 +127,6 @@ defmodule LiveSelect do
   send_update(LiveSelect.Component, id: live_select_id, value: new_selection)
   ```
 
-  `new_selection` must be a single element in `:single` mode, a list in `:tags` mode. If it's `nil`, the selection will be cleared.  
-  After updating the selection, `LiveSelect` will trigger a change event in the form.  
   `new_selection` must be a single element in `:single` mode, a list in `:tags` mode. If it's `nil`, the selection will be cleared.
   After updating the selection, `LiveSelect` will trigger a change event in the form.
 

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -164,12 +164,12 @@ defmodule LiveSelect.Component do
         socket
       end
 
-
     socket =
       cond do
         Map.has_key?(assigns, :value) ->
           update(socket, :selection, fn
-            selection, %{options: options, value: value, mode: mode, value_mapper: value_mapper} ->
+            selection,
+            %{options: options, value: value, mode: mode, value_mapper: value_mapper} ->
               update_selection(value, selection, options, mode, value_mapper)
           end)
           |> client_select(%{input_event: true})
@@ -549,9 +549,10 @@ defmodule LiveSelect.Component do
   defp append_selection(value, current_selection, :tags, value_mapper) do
     value = if Enumerable.impl_for(value), do: value, else: [value]
 
-    normalized_value = Enum.map(value, &normalize_selection_value(&1, current_selection, value_mapper))
+    normalized_value =
+      Enum.map(value, &normalize_selection_value(&1, current_selection, value_mapper))
 
-    current_selection ++ normalized_value
+    (current_selection ++ normalized_value)
     |> Enum.reject(&is_nil/1)
     |> Enum.uniq()
   end

--- a/test/live_select_tags_test.exs
+++ b/test/live_select_tags_test.exs
@@ -379,6 +379,58 @@ defmodule LiveSelectTagsTest do
     assert_selected_multiple(live, [%{label: "C", value: 3}, %{label: "E", value: 5}])
   end
 
+  test "can append values to the selection", %{conn: conn} do
+    {:ok, live, _html} = live(conn, "/?mode=tags")
+
+    stub_options(~w(A B C))
+
+    type(live, "ABC")
+
+    select_nth_option(live, 1)
+
+    assert_selected_multiple(live, ~w(A))
+
+    send_update(live, append: ["B"])
+
+    assert_selected_multiple(live, ~w(A B))
+
+    send_update(live, append: "C")
+
+    assert_selected_multiple(live, ~w(A B C))
+  end
+
+  test "does not duplicate selection when appending values", %{conn: conn} do
+    {:ok, live, _html} = live(conn, "/?mode=tags")
+
+    stub_options(~w(A B C))
+
+    type(live, "ABC")
+
+    select_nth_option(live, 1)
+
+    assert_selected_multiple(live, ~w(A))
+
+    send_update(live, append: ~w(A))
+
+    assert_selected_multiple(live, ~w(A))
+  end
+
+  test "does not change the selection when appending nil values", %{conn: conn} do
+    {:ok, live, _html} = live(conn, "/?mode=tags")
+
+    stub_options(~w(A B C))
+
+    type(live, "ABC")
+
+    select_nth_option(live, 1)
+
+    assert_selected_multiple(live, ~w(A))
+
+    send_update(live, append: nil)
+
+    assert_selected_multiple(live, ~w(A))
+  end
+
   test "can render custom clear button", %{conn: conn} do
     {:ok, live, _html} = live(conn, "/live_component_test")
 


### PR DESCRIPTION
This is motivated by our need to allow the user to add a preset list of values to a selection group at any moment without replacing already selected values.

This is the minimum code for it to work. Please let me know how it can be improved. :D