### PR TITLE
Adds `:filter_values` option to conditionally keep or remove items from the selection

### DIFF
--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -129,9 +129,22 @@ defmodule LiveSelect do
 
   `new_selection` must be a single element in `:single` mode, a list in `:tags` mode. If it's `nil`, the selection will be cleared.  
   After updating the selection, `LiveSelect` will trigger a change event in the form.  
+  `new_selection` must be a single element in `:single` mode, a list in `:tags` mode. If it's `nil`, the selection will be cleared.
+  After updating the selection, `LiveSelect` will trigger a change event in the form.
 
   To set a custom id for the component to use with `Phoenix.LiveView.send_update/3`, you can pass the `id` assign to `live_select/1`.
 
+  ### Appending to the selection in `:tags` mode
+
+  When you want to append to the current selection, you can use the `:append` key in the `send_update` call:
+
+  ```
+  send_update(LiveSelect.Component, id: live_select_id, append: values_to_append)
+  ```
+
+  `values_to_append` can be a single element or a list to append to the current selection. If the value to append already exists in the selection, it will be ignored.
+
+  Note: This does not work in `:single` mode. Use `:value` instead to replace the selection.
 
   ## Examples
 

--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -127,8 +127,6 @@ defmodule LiveSelect do
   send_update(LiveSelect.Component, id: live_select_id, value: new_selection)
   ```
 
-  `new_selection` must be a single element in `:single` mode, a list in `:tags` mode. If it's `nil`, the selection will be cleared.  
-  After updating the selection, `LiveSelect` will trigger a change event in the form.  
   `new_selection` must be a single element in `:single` mode, a list in `:tags` mode. If it's `nil`, the selection will be cleared.
   After updating the selection, `LiveSelect` will trigger a change event in the form.
 

--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -132,6 +132,16 @@ defmodule LiveSelect do
 
   To set a custom id for the component to use with `Phoenix.LiveView.send_update/3`, you can pass the `id` assign to `live_select/1`.
 
+  ### Dynamically filtering the selection
+
+  You can conditionally filter the selection to remove or keep items matching a criteria by passing an 1 arity function to `:filter_values`:
+
+  ```
+  send_update(LiveSelect.Component, id: live_select_id, filter_values: fn value -> String.length(value.label) > 3 end)
+  ```
+
+  In this case, only the values with a label longer than 3 characters will be kept in the selection.
+
   ### Appending to the selection in `:tags` mode
 
   When you want to append to the current selection, you can use the `:append` key in the `send_update` call:

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -185,6 +185,16 @@ defmodule LiveSelect.Component do
           socket
       end
 
+    socket =
+      if Map.has_key?(assigns, :filter_values) do
+        update(socket, :selection, fn selection, %{filter_values: filter} ->
+          filter_selection(filter, selection)
+        end)
+        |> client_select(%{input_event: true})
+      else
+        socket
+      end
+
     {:ok, socket}
   end
 
@@ -376,6 +386,7 @@ defmodule LiveSelect.Component do
           :hide_dropdown,
           :value_mapper,
           :append,
+          :filter_values,
           # for backwards compatibility
           :form
         ]
@@ -555,6 +566,16 @@ defmodule LiveSelect.Component do
     (current_selection ++ normalized_value)
     |> Enum.reject(&is_nil/1)
     |> Enum.uniq()
+  end
+
+  defp filter_selection(filter, selection) when is_function(filter, 1) do
+    Enum.filter(selection, filter)
+  end
+
+  defp filter_selection(_filter, _value) do
+    raise """
+    Option for `:filter_values` must be a function with arity 1
+    """
   end
 
   defp normalize_selection_value(%Ecto.Changeset{action: :replace}, _options, _value_mapper),

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -164,12 +164,12 @@ defmodule LiveSelect.Component do
         socket
       end
 
-
     socket =
       cond do
         Map.has_key?(assigns, :value) ->
           update(socket, :selection, fn
-            selection, %{options: options, value: value, mode: mode, value_mapper: value_mapper} ->
+            selection,
+            %{options: options, value: value, mode: mode, value_mapper: value_mapper} ->
               update_selection(value, selection, options, mode, value_mapper)
           end)
           |> client_select(%{input_event: true})
@@ -549,9 +549,10 @@ defmodule LiveSelect.Component do
   defp append_selection(value, current_selection, :tags, value_mapper) do
     value = if Enumerable.impl_for(value), do: value, else: [value]
 
-    normalized_value = Enum.map(value, &normalize_selection_value(&1, current_selection, value_mapper))
+    normalized_value =
+      Enum.map(value, &normalize_selection_value(&1, current_selection, value_mapper))
 
-    current_selection ++ normalized_value
+    (current_selection ++ normalized_value)
     |> Enum.reject(&is_nil/1)
     |> Enum.uniq()
   end

--- a/test/live_select_tags_test.exs
+++ b/test/live_select_tags_test.exs
@@ -379,6 +379,58 @@ defmodule LiveSelectTagsTest do
     assert_selected_multiple(live, [%{label: "C", value: 3}, %{label: "E", value: 5}])
   end
 
+  test "can append values to the selection", %{conn: conn} do
+    {:ok, live, _html} = live(conn, "/?mode=tags")
+
+    stub_options(~w(A B C))
+
+    type(live, "ABC")
+
+    select_nth_option(live, 1)
+
+    assert_selected_multiple(live, ~w(A))
+
+    send_update(live, append: ["B"])
+
+    assert_selected_multiple(live, ~w(A B))
+
+    send_update(live, append: "C")
+
+    assert_selected_multiple(live, ~w(A B C))
+  end
+
+  test "does not duplicate selection when appending values", %{conn: conn} do
+    {:ok, live, _html} = live(conn, "/?mode=tags")
+
+    stub_options(~w(A B C))
+
+    type(live, "ABC")
+
+    select_nth_option(live, 1)
+
+    assert_selected_multiple(live, ~w(A))
+
+    send_update(live, append: ~w(A))
+
+    assert_selected_multiple(live, ~w(A))
+  end
+
+  test "does not change the selection when appending nil values", %{conn: conn} do
+    {:ok, live, _html} = live(conn, "/?mode=tags")
+
+    stub_options(~w(A B C))
+
+    type(live, "ABC")
+
+    select_nth_option(live, 1)
+
+    assert_selected_multiple(live, ~w(A))
+
+    send_update(live, append: nil)
+
+    assert_selected_multiple(live, ~w(A))
+  end
+
   test "can render custom clear button", %{conn: conn} do
     {:ok, live, _html} = live(conn, "/live_component_test")
 

--- a/test/live_select_tags_test.exs
+++ b/test/live_select_tags_test.exs
@@ -431,6 +431,18 @@ defmodule LiveSelectTagsTest do
     assert_selected_multiple(live, ~w(A))
   end
 
+  test "can filter selection values", %{conn: conn} do
+    {:ok, live, _html} = live(conn, "/?mode=tags")
+
+    send_update(live, value: ~w(A B))
+
+    assert_selected_multiple(live, ~w(A B))
+
+    send_update(live, filter_values: fn value -> value.label == "A" end)
+
+    assert_selected_multiple(live, ~w(A))
+  end
+
   test "can render custom clear button", %{conn: conn} do
     {:ok, live, _html} = live(conn, "/live_component_test")
 

--- a/test/live_select_test.exs
+++ b/test/live_select_test.exs
@@ -621,6 +621,24 @@ defmodule LiveSelectTest do
     assert_selected(live, :D, 4)
   end
 
+  test "can filter selection values", %{conn: conn} do
+    stub_options(A: 1)
+
+    {:ok, live, _html} = live(conn, "/")
+
+    send_update(live, value: 1, options: [A: 1])
+
+    assert_selected(live, :A, 1)
+
+    send_update(live, filter_values: fn opt -> opt.value == 1 end)
+
+    assert_selected(live, :A, 1)
+
+    send_update(live, filter_values: fn opt -> opt.value == 2 end)
+
+    refute_selected(live)
+  end
+
   test "renders custom :option slots", %{conn: conn} do
     {:ok, live, _html} = live(conn, "/live_component_test")
 


### PR DESCRIPTION
This is based off #63 this is why it has both changes.

This allows running a function against selected values to keep/discard items.

This is the motivation behind this change:

We allow the user to "tag" other users when creating some records using LiveSelect.
There is a field that controls if the record is "sensitive".
When that field changes, if it changes to "sensitive", we must remove previously "tagged" users that can't see sensitive information.