### PR TITLE
New variant for tags-mode

### DIFF
--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -370,14 +370,10 @@ defmodule LiveSelect do
       ~S(an id to assign to the component. If none is provided, `#{form_name}_#{field}_live_select_component` will be used)
 
   attr :mode, :atom,
-    values: [:single, :tags],
+    values: [:single, :tags, :quick_tags],
     default: Component.default_opts()[:mode],
-    doc: "either `:single` (for single selection), or `:tags` (for multiple selection using tags)"
-
-  attr :tags_mode, :atom,
-    values: [:default, :multiple_select],
-    default: Component.default_opts()[:tags_mode],
-    doc: "whether to use default tags mode or multi-select tags mode. Multi-select mode enables selecting multiple options without the options dropdown being hidden"
+    doc:
+      "either `:single` (for single selection), `:tags` (for multiple selection using tags), or :quick_tags (tags mode but can select multiple at a time)"
 
   attr :options, :list,
     doc:

--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -374,6 +374,11 @@ defmodule LiveSelect do
     default: Component.default_opts()[:mode],
     doc: "either `:single` (for single selection), or `:tags` (for multiple selection using tags)"
 
+  attr :tags_mode, :atom,
+    values: [:default, :multiple_select],
+    default: Component.default_opts()[:tags_mode],
+    doc: "whether to use default tags mode or multi-select tags mode. Multi-select mode enables selecting multiple options without the options dropdown being hidden"
+
   attr :options, :list,
     doc:
       ~s(initial available options to select from. Note that, after the initial rendering of the component, options can only be updated using `Phoenix.LiveView.send_update/3` - See the "Options" section for details)

--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -6,12 +6,12 @@ defmodule LiveSelect do
   @moduledoc ~S"""
   The `LiveSelect` component is rendered by calling the `live_select/1` function and passing it a form field.
   LiveSelect creates a text input field in which the user can type text, and hidden input field(s) that will contain the value of the selected option(s).
-    
+
   Whenever the user types something in the text input, LiveSelect triggers a `live_select_change` event for your LiveView or LiveComponent.
-  The message has a `text` parameter containing the current text entered by the user, as well as `id` and `field` parameters with the id of the 
+  The message has a `text` parameter containing the current text entered by the user, as well as `id` and `field` parameters with the id of the
   LiveSelect component and the name of the LiveSelect form field, respectively.
   Your job is to handle the event, retrieve the list of selectable options and then call `Phoenix.LiveView.send_update/3`
-  to send the list of options to LiveSelect. See the "Examples" section below for details, and check out the 
+  to send the list of options to LiveSelect. See the "Examples" section below for details, and check out the
   [cheatsheet](https://hexdocs.pm/live_select/cheatsheet.html) for some useful tips.
 
   Selection can happen either using the keyboard, by navigating the options with the arrow keys and then pressing enter, or by
@@ -23,12 +23,12 @@ defmodule LiveSelect do
   In single mode, if the configuration option `allow_clear` is set, the user can manually clear the selection by clicking on the `x` button on the input field.
   In tags mode, single tags can be removed by clicking on them.
 
-  ## Single mode  
+  ## Single mode
 
   <img alt="demo" src="https://raw.githubusercontent.com/maxmarcon/live_select/main/priv/static/images/demo_single.gif" width="300" />
 
   ## Tags mode
-    
+
   <img alt="demo" src="https://raw.githubusercontent.com/maxmarcon/live_select/main/priv/static/images/demo_tags.gif" width="300" />
 
   When `:tags` mode is enabled `LiveSelect` allows the user to select multiple entries. The entries will be visible above the text input field as removable tags.
@@ -46,7 +46,7 @@ defmodule LiveSelect do
 
   * _atoms, strings or numbers_: In this case, each element will be both label and value for the option
   * _tuples_: `{label, value}` corresponding to label and value for the option
-  * _maps_: `%{label: label, value: value}` or `%{value: value}` 
+  * _maps_: `%{label: label, value: value}` or `%{value: value}`
   * _keywords_: `[label: label, value: value]` or `[value: value]`
 
   In the case of maps and keywords, if only `value` is specified, it will be used as both value and label for the option.
@@ -61,23 +61,23 @@ defmodule LiveSelect do
 
   Note that the option values, if they are not strings, will be JSON-encoded. Your LiveView will receive this JSON-encoded version in the `phx-change` and `phx-submit` events.
 
-  ## Styling 
-    
+  ## Styling
+
   `LiveSelect` supports 3 styling modes:
 
   * `tailwind`: uses standard tailwind utility classes (the default)
   * `daisyui`: uses [daisyUI](https://daisyui.com/) classes.
   * `none`: no styling at all.
 
-  Please see [the styling section](styling.md) for details 
+  Please see [the styling section](styling.md) for details
 
   ## Alternative tag labels
-    
-  Sometimes, in `:tags` mode, you might want to use alternative labels for the tags. For example, you might want the labels in the tags to be shorter 
+
+  Sometimes, in `:tags` mode, you might want to use alternative labels for the tags. For example, you might want the labels in the tags to be shorter
   in order to save space. You can do this by specifying an additional `tag_label` key when passing options as map or keywords. For example, passing these options:
 
   ```
-  [%{label: "New York", value: "NY", tag_label: "NY"}, %{label: "Barcelona", value: "BCN", tag_label: "BCN"}]  
+  [%{label: "New York", value: "NY", tag_label: "NY"}, %{label: "Barcelona", value: "BCN", tag_label: "BCN"}]
   ```
 
   will result in "New York" and "Barcelona" being used for the options in the dropdown, while "NY" and "BCN" will be used for the tags (and the values).
@@ -93,11 +93,11 @@ defmodule LiveSelect do
   Now, whenever the selection contains "New York", the option will stick and the user won't be able to remove it.
 
   ## Slots
-    
+
   You can control how your options and tags are rendered by using the `:option` and `:tag` slots.
   Let's say you want to show some fancy icons next to each option in the dropdown and the tags:
 
-  ```elixir  
+  ```elixir
   <.live_select
           field={@form[:city_search]}
           phx-target={@myself}
@@ -115,7 +115,7 @@ defmodule LiveSelect do
   ```
 
   Here's the result:
-      
+
   <img alt="slots" src="https://raw.githubusercontent.com/maxmarcon/live_select/main/priv/static/images/slots.png" width="200" />
 
   ## Controlling the selection programmatically
@@ -127,8 +127,8 @@ defmodule LiveSelect do
   send_update(LiveSelect.Component, id: live_select_id, value: new_selection)
   ```
 
-  `new_selection` must be a single element in `:single` mode, a list in `:tags` mode. If it's `nil`, the selection will be cleared.  
-  After updating the selection, `LiveSelect` will trigger a change event in the form.  
+  `new_selection` must be a single element in `:single` mode, a list in `:tags` mode. If it's `nil`, the selection will be cleared.
+  After updating the selection, `LiveSelect` will trigger a change event in the form.
 
   To set a custom id for the component to use with `Phoenix.LiveView.send_update/3`, you can pass the `id` assign to `live_select/1`.
 
@@ -148,23 +148,23 @@ defmodule LiveSelect do
   _Template:_
   ```
   <.form for={@form} phx-change="change">
-    <.live_select field={@form[:city_search]} /> 
+    <.live_select field={@form[:city_search]} />
   </.form>
   ```
-    
+
   > #### Forms implemented in LiveComponents {: .warning}
-  > 
+  >
   > If your form is implemented in a LiveComponent and not in a LiveView, you have to add the `phx-target` attribute
   > when rendering LiveSelect:
   >
   > ```elixir
   >  <.live_select field={@form[:city_search]} phx-target={@myself} />
-  > ```  
-    
+  > ```
+
   _LiveView or LiveComponent that is the target of the form's events:_
   ```
   @impl true
-  def handle_event("live_select_change", %{"text" => text, "id" => live_select_id}, socket) do 
+  def handle_event("live_select_change", %{"text" => text, "id" => live_select_id}, socket) do
       cities = City.search(text)
       # cities could be:
       # [ {"city name 1", [lat_1, long_1]}, {"city name 2", [lat_2, long_2]}, ... ]
@@ -173,13 +173,13 @@ defmodule LiveSelect do
       # [ "city name 1", "city name 2", ... ]
       #
       # or:
-      # [ [label: "city name 1", value: [lat_1, long_1]], [label: "city name 2", value: [lat_2, long_2]], ... ] 
+      # [ [label: "city name 1", value: [lat_1, long_1]], [label: "city name 2", value: [lat_2, long_2]], ... ]
       #
       # or even:
       # ["city name 1": [lat_1, long_1], "city name 2": [lat_2, long_2]]
 
       send_update(LiveSelect.Component, id: live_select_id, options: cities)
-    
+
       {:noreply, socket}
   end
 
@@ -192,7 +192,7 @@ defmodule LiveSelect do
       IO.puts("You selected city #{city_name} located at: #{city_coords}")
 
       {:noreply, socket}
-  end  
+  end
   ```
 
   ### Tags mode
@@ -203,7 +203,7 @@ defmodule LiveSelect do
   _Template:_
   ```
   <.form for={@form} phx-change="change">
-    <.live_select field={@form[:city_search]} mode={:tags} /> 
+    <.live_select field={@form[:city_search]} mode={:tags} />
   </.form>
   ```
 
@@ -216,17 +216,17 @@ defmodule LiveSelect do
       socket
     ) do
     # list_of_coords will contain the list of the JSON-encoded coordinates of the selected cities, for example:
-    # ["[-46.565,-23.69389]", "[-48.27722,-18.91861]"]    
+    # ["[-46.565,-23.69389]", "[-48.27722,-18.91861]"]
 
     IO.puts("You selected cities located at: #{list_of_coords}")
 
     {:noreply, socket}
-  end  
+  end
   ```
 
-  ### Multiple LiveSelect inputs in the same LiveView  
+  ### Multiple LiveSelect inputs in the same LiveView
 
-  If you have multiple LiveSelect inputs in the same LiveView, you can distinguish them based on the field id. 
+  If you have multiple LiveSelect inputs in the same LiveView, you can distinguish them based on the field id.
   For example:
 
   _Template:_
@@ -255,10 +255,10 @@ defmodule LiveSelect do
 
   ## Using LiveSelect with associations and embeds
 
-  LiveSelect can also be used to display and select associations or embeds without too much effort. 
-  Let's say you have the following schemas:  
-    
-  ```  
+  LiveSelect can also be used to display and select associations or embeds without too much effort.
+  Let's say you have the following schemas:
+
+  ```
   defmodule City do
     @moduledoc false
 
@@ -292,7 +292,7 @@ defmodule LiveSelect do
     end
   end
   ```
-    
+
   Each city has a name and an array with coordinates - we want `LiveSelect` to display the name as label in the dropdown and in the tags, but we want
   the entire data structure (name + coordinates) to be sent to the server when the user selects.
 
@@ -329,20 +329,20 @@ defmodule LiveSelect do
     {:noreply, socket}
   end
   ```
-    
+
   > #### IMPORTANT: the output of the `value_mapper/1` function should be JSON-encodable {: .warning}
 
-  Finally, in order to take care of (2) you need to decode the JSON-encoded list of options that's coming from the client before you can 
+  Finally, in order to take care of (2) you need to decode the JSON-encoded list of options that's coming from the client before you can
   cast them to create a changeset. To do so, `LiveSelect` offers a convenience function called `LiveSelect.decode/1`:
   ```
   def handle_event("change", params, socket) do
-    # decode will JSON-decode the value in city_search, handling the type of selection 
+    # decode will JSON-decode the value in city_search, handling the type of selection
     # and taking care of special values such as "" and nil
     params = update_in(params, ~w(city_search_form city_search), &LiveSelect.decode/1)
-    
+
     # now we can cast the params:
     changeset = CitySearchForm.changeset(params)
-    
+
     {:noreply, assign(socket, form: to_form(changeset))}
   end
   ```
@@ -352,12 +352,12 @@ defmodule LiveSelect do
 
   @doc ~S"""
   Renders a `LiveSelect` input in a form.
-    
+
   [INSERT LVATTRDOCS]
 
   ## Styling attributes
 
-  * See [the styling section](styling.md) for details 
+  * See [the styling section](styling.md) for details
   """
   @doc type: :component
 
@@ -373,13 +373,13 @@ defmodule LiveSelect do
     values: [:single, :tags, :quick_tags],
     default: Component.default_opts()[:mode],
     doc:
-      "either `:single` (for single selection), `:tags` (for multiple selection using tags), or :quick_tags (tags mode but can select multiple at a time)"
+      "either `:single` (for single selection), `:tags` (for multiple selection using tags), or :quick_tags (like tags but that dropdown stays open after selection)"
 
   attr :options, :list,
     doc:
       ~s(initial available options to select from. Note that, after the initial rendering of the component, options can only be updated using `Phoenix.LiveView.send_update/3` - See the "Options" section for details)
 
-  attr :value, :any, doc: "used to manually set a selection - overrides any values from the form. 
+  attr :value, :any, doc: "used to manually set a selection - overrides any values from the form.
   Must be a single element in `:single` mode, or a list of elements in `:tags` mode."
 
   attr :max_selectable, :integer,
@@ -480,27 +480,27 @@ defmodule LiveSelect do
 
   @doc ~S"""
   Decodes the selection from the client. This has to be used when the values in the selection aren't simple integers or strings.
-    
-  Let's say you receive your params in the variable `params`, and your `LiveSelect` field is called `my_field` and belongs to the form `my_form`. Then you should  
+
+  Let's say you receive your params in the variable `params`, and your `LiveSelect` field is called `my_field` and belongs to the form `my_form`. Then you should
   decode like this:
 
   ```
   params = update_in(params, ~w(my_form my_field), &LiveSelect.decode/1)
   ```
-    
-  ## Examples:  
+
+  ## Examples:
 
     iex> decode(nil)
     []
-        
+
     iex> decode("")
     nil
-      
+
     iex> decode("{\"name\":\"Berlin\",\"pos\":[13.41053,52.52437]}")
     %{"name" => "Berlin","pos" => [13.41053,52.52437]}
-      
+
     iex> decode(["{\"name\":\"New York City\",\"pos\":[-74.00597,40.71427]}","{\"name\":\"Stockholm\",\"pos\":[18.06871,59.32938]}"])
-    [%{"name" => "New York City","pos" => [-74.00597,40.71427]}, %{"name" => "Stockholm","pos" => [18.06871,59.32938]}] 
+    [%{"name" => "New York City","pos" => [-74.00597,40.71427]}, %{"name" => "Stockholm","pos" => [18.06871,59.32938]}]
   """
   def decode(selection) do
     case selection do

--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -373,7 +373,7 @@ defmodule LiveSelect do
     values: [:single, :tags, :quick_tags],
     default: Component.default_opts()[:mode],
     doc:
-      "either `:single` (for single selection), `:tags` (for multiple selection using tags), or :quick_tags (like tags can be selected/deselected in quick succession)"
+      "either `:single` (for single selection), `:tags` (for multiple selection using tags), or :quick_tags (multiple selection but tags can be selected/deselected in quick succession)"
 
   attr :options, :list,
     doc:

--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -373,7 +373,7 @@ defmodule LiveSelect do
     values: [:single, :tags, :quick_tags],
     default: Component.default_opts()[:mode],
     doc:
-      "either `:single` (for single selection), `:tags` (for multiple selection using tags), or :quick_tags (like tags but that dropdown stays open after selection)"
+      "either `:single` (for single selection), `:tags` (for multiple selection using tags), or :quick_tags (like tags can be selected/deselected in quick succession)"
 
   attr :options, :list,
     doc:

--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -95,6 +95,9 @@ defmodule LiveSelect do
   ## Slots
 
   You can control how your options and tags are rendered by using the `:option` and `:tag` slots.
+  Both slots will be passed an option as argument. In the case of the `:option` slot, the option will have an
+  extra boolean field `:selected`, which will be set to `true` if the option has been selected by the user.
+
   Let's say you want to show some fancy icons next to each option in the dropdown and the tags:
 
   ```elixir

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -435,13 +435,13 @@ defmodule LiveSelect.Component do
          extra_params
        )
        when active_option >= 0 do
-    option = Enum.at(socket.assigns.options, active_option)
+    option = Enum.at(options, active_option)
 
     if already_selected?(option, selection) do
       pos = get_selection_index(option, selection)
       unselect(socket, pos)
     else
-      select(socket, Enum.at(socket.assigns.options, socket.assigns.active_option), extra_params)
+      select(socket, Enum.at(options, active_option), extra_params)
     end
   end
 
@@ -710,7 +710,6 @@ defmodule LiveSelect.Component do
   defp next_selectable(%{
          options: options,
          active_option: active_option,
-         selection: selection,
          mode: :quick_tags
        }) do
     options
@@ -739,7 +738,6 @@ defmodule LiveSelect.Component do
   defp prev_selectable(%{
          options: options,
          active_option: active_option,
-         selection: selection,
          mode: :quick_tags
        }) do
     options

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -201,7 +201,11 @@ defmodule LiveSelect.Component do
         &if &1.assigns.mode == :single do
           clear(&1, %{input_event: false, parent_event: &1.assigns[:"phx-focus"]})
         else
-          parent_event(&1, &1.assigns[:"phx-focus"], %{id: &1.assigns.id})
+          if &1.assigns.tags_mode == :multiple_select do
+            &1
+          else
+            parent_event(&1, &1.assigns[:"phx-focus"], %{id: &1.assigns.id})
+          end
         end
       )
       |> assign(hide_dropdown: false)
@@ -466,8 +470,7 @@ defmodule LiveSelect.Component do
 
     socket
     |> assign(
-      active_option:
-        if(multi_select_mode?(socket), do: socket.assigns.active_option, else: -1),
+      active_option: if(multi_select_mode?(socket), do: socket.assigns.active_option, else: -1),
       selection: selection,
       hide_dropdown: not multi_select_mode?(socket)
     )
@@ -691,7 +694,7 @@ defmodule LiveSelect.Component do
   end
 
   def already_selected?(option, selection) do
-    option.label in Enum.map(selection, & &1.label)
+    Enum.any?(selection, fn item -> item.label == option.label end)
   end
 
   defp multi_select_mode?(socket) do

--- a/lib/live_select/component.html.heex
+++ b/lib/live_select/component.html.heex
@@ -8,10 +8,11 @@
   data-field={@field.id}
   data-debounce={@debounce}
 >
-  <%= if @mode == :tags && Enum.any?(@selection) do %>
+
     <div class={
       class(@style, :tags_container, @tags_container_class, @tags_container_extra_class)
     }>
+    <%= if (@mode == :tags || @mode == :quick_tags) && Enum.any?(@selection) do %>
       <%= for {option, idx} <- Enum.with_index(@selection) do %>
         <div class={class(@style, :tag, @tag_class, @tag_extra_class)}>
           <%= if @tag == [] do %>
@@ -40,8 +41,9 @@
           </button>
         </div>
       <% end %>
+      <% end %>
     </div>
-  <% end %>
+
   <div>
     <%= text_input(@field.form, @text_input_field,
       class:
@@ -127,7 +129,7 @@
             <%= if @option == [] do %>
               <%= option.label %>
             <% else %>
-              <%= render_slot(@option, {option, already_selected?(option, @selection)}) %>
+              <%= render_slot(@option, Map.merge(option, %{selected: already_selected?(option, @selection)})) %>
             <% end %>
           </div>
         </li>

--- a/lib/live_select/component.html.heex
+++ b/lib/live_select/component.html.heex
@@ -122,12 +122,12 @@
                   )
                 )
             }
-            data-idx={unless already_selected?(option, @selection), do: idx}
+            data-idx={idx}
           >
             <%= if @option == [] do %>
               <%= option.label %>
             <% else %>
-              <%= render_slot(@option, option) %>
+              <%= render_slot(@option, {option, already_selected?(option, @selection)}) %>
             <% end %>
           </div>
         </li>

--- a/lib/live_select/component.html.heex
+++ b/lib/live_select/component.html.heex
@@ -8,10 +8,7 @@
   data-field={@field.id}
   data-debounce={@debounce}
 >
-
-    <div class={
-      class(@style, :tags_container, @tags_container_class, @tags_container_extra_class)
-    }>
+  <div class={class(@style, :tags_container, @tags_container_class, @tags_container_extra_class)}>
     <%= if (@mode == :tags || @mode == :quick_tags) && Enum.any?(@selection) do %>
       <%= for {option, idx} <- Enum.with_index(@selection) do %>
         <div class={class(@style, :tag, @tag_class, @tag_extra_class)}>
@@ -41,8 +38,8 @@
           </button>
         </div>
       <% end %>
-      <% end %>
-    </div>
+    <% end %>
+  </div>
 
   <div>
     <%= text_input(@field.form, @text_input_field,
@@ -124,12 +121,17 @@
                   )
                 )
             }
-            data-idx={idx}
+            data-idx={
+              if @mode == :quick_tags or not already_selected?(option, @selection), do: idx
+            }
           >
             <%= if @option == [] do %>
               <%= option.label %>
             <% else %>
-              <%= render_slot(@option, Map.merge(option, %{selected: already_selected?(option, @selection)})) %>
+              <%= render_slot(
+                @option,
+                Map.merge(option, %{selected: already_selected?(option, @selection)})
+              ) %>
             <% end %>
           </div>
         </li>

--- a/lib/live_select/component.html.heex
+++ b/lib/live_select/component.html.heex
@@ -9,7 +9,7 @@
   data-debounce={@debounce}
 >
   <div class={class(@style, :tags_container, @tags_container_class, @tags_container_extra_class)}>
-    <%= if (@mode == :tags || @mode == :quick_tags) && Enum.any?(@selection) do %>
+    <%= if (@mode in [:tags, :quick_tags]) && Enum.any?(@selection) do %>
       <%= for {option, idx} <- Enum.with_index(@selection) do %>
         <div class={class(@style, :tag, @tag_class, @tag_extra_class)}>
           <%= if @tag == [] do %>

--- a/lib/support/live_select_web/live/showcase_live.html.heex
+++ b/lib/support/live_select_web/live/showcase_live.html.heex
@@ -44,6 +44,12 @@
               class: "select select-sm select-bordered text-xs"
             )}
           </div>
+          <div :if={@settings_form[:mode].value == :tags} class="form-control max-w-sm">
+            <%= label(@settings_form, :tags_mode, "Tags mode:", class: "label label-text font-semibold") %>
+            <%= select(@settings_form, :tags_mode, [:default, :multiple_select],
+              class: "select select-sm select-bordered text-xs"
+            ) %>
+          </div>
           <div class="form-control max-w-sm">
             {label(@settings_form, :max_selectable, "Max selectable:",
               class: "label label-text font-semibold"

--- a/lib/support/live_select_web/live/showcase_live.html.heex
+++ b/lib/support/live_select_web/live/showcase_live.html.heex
@@ -40,15 +40,9 @@
         <div class="flex flex-wrap p-5 gap-2">
           <div class="form-control max-w-sm">
             {label(@settings_form, :mode, "Mode:", class: "label label-text font-semibold")}
-            {select(@settings_form, :mode, [:single, :tags],
+            {select(@settings_form, :mode, [:single, :tags, :quick_tags],
               class: "select select-sm select-bordered text-xs"
             )}
-          </div>
-          <div :if={@settings_form[:mode].value == :tags} class="form-control max-w-sm">
-            <%= label(@settings_form, :tags_mode, "Tags mode:", class: "label label-text font-semibold") %>
-            <%= select(@settings_form, :tags_mode, [:default, :multiple_select],
-              class: "select select-sm select-bordered text-xs"
-            ) %>
           </div>
           <div class="form-control max-w-sm">
             {label(@settings_form, :max_selectable, "Max selectable:",
@@ -76,6 +70,10 @@
             <%= label class: "label cursor-pointer" do %>
               <span class="label-text mr-1">Disabled:&nbsp;</span>
               {checkbox(@settings_form, :disabled, class: "toggle")}
+            <% end %>
+            <%= label class: "label cursor-pointer" do %>
+              <span class="label-text mr-1">Custom option HTML:&nbsp;</span>
+              <%= checkbox(@settings_form, :custom_option_html, class: "toggle") %>
             <% end %>
           </div>
           <div class="form-control max-w-sm">
@@ -292,7 +290,22 @@
                 field={@live_select_form[:city_search]}
                 value_mapper={&value_mapper/1}
                 {live_select_assigns(@settings_form.source)}
-              />
+              >
+              <:option :let={%{label: label, value: value, selected: selected}}>
+                <%= if @settings_form[:custom_option_html].value do %>
+                  <div class="flex justify-content items-center">
+                    <input
+                      class="rounded w-4 h-4 mr-3 border border-border"
+                      type="checkbox"
+                      checked={selected}
+                    />
+                    <span class="text-sm"><%= label %></span>
+                  </div>
+                <% else %>
+                  <%= label %>
+                <% end %>
+              </:option>
+            </.live_select>
             </div>
             <div class="flex flex-col gap-y-1">
               {submit("Submit",
@@ -316,7 +329,7 @@
       </div>
 
       <div
-        class="w-full md:w-2/3 mt-5 relative border-info border rounded-lg p-2"
+        class="w-full md:w-2/3 mt-5 mb-5 relative border-info border rounded-lg p-2"
         id="live-select-code"
       >
         <div
@@ -332,7 +345,7 @@
             <.copy_to_clipboard_icon />
           </button>
         </div>
-        <Render.live_select opts={Settings.live_select_opts(@settings_form.data, true)} />
+        <Render.live_select custom_option_html={@settings_form[:custom_option_html].value} opts={Settings.live_select_opts(@settings_form.data, true)} />
       </div>
     </div>
   </div>

--- a/lib/support/live_select_web/live/showcase_live.html.heex
+++ b/lib/support/live_select_web/live/showcase_live.html.heex
@@ -291,21 +291,21 @@
                 value_mapper={&value_mapper/1}
                 {live_select_assigns(@settings_form.source)}
               >
-              <:option :let={%{label: label, value: value, selected: selected}}>
-                <%= if @settings_form[:custom_option_html].value do %>
-                  <div class="flex justify-content items-center">
-                    <input
-                      class="rounded w-4 h-4 mr-3 border border-border"
-                      type="checkbox"
-                      checked={selected}
-                    />
-                    <span class="text-sm"><%= label %></span>
-                  </div>
-                <% else %>
-                  <%= label %>
-                <% end %>
-              </:option>
-            </.live_select>
+                <:option :let={%{label: label, value: _value, selected: selected}}>
+                  <%= if @settings_form[:custom_option_html].value do %>
+                    <div class="flex justify-content items-center">
+                      <input
+                        class="rounded w-4 h-4 mr-3 border border-border"
+                        type="checkbox"
+                        checked={selected}
+                      />
+                      <span class="text-sm"><%= label %></span>
+                    </div>
+                  <% else %>
+                    <%= label %>
+                  <% end %>
+                </:option>
+              </.live_select>
             </div>
             <div class="flex flex-col gap-y-1">
               {submit("Submit",
@@ -345,7 +345,10 @@
             <.copy_to_clipboard_icon />
           </button>
         </div>
-        <Render.live_select custom_option_html={@settings_form[:custom_option_html].value} opts={Settings.live_select_opts(@settings_form.data, true)} />
+        <Render.live_select
+          custom_option_html={@settings_form[:custom_option_html].value}
+          opts={Settings.live_select_opts(@settings_form.data, true)}
+        />
       </div>
     </div>
   </div>

--- a/lib/support/live_select_web/live/showcase_live.html.heex
+++ b/lib/support/live_select_web/live/showcase_live.html.heex
@@ -72,7 +72,7 @@
               {checkbox(@settings_form, :disabled, class: "toggle")}
             <% end %>
             <%= label class: "label cursor-pointer" do %>
-              <span class="label-text mr-1">Options styles as checkboxes:&nbsp;</span>
+              <span class="label-text mr-1">Options styled as checkboxes:&nbsp;</span>
               <%= checkbox(@settings_form, :options_styled_as_checkboxes, class: "toggle") %>
             <% end %>
           </div>

--- a/lib/support/live_select_web/live/showcase_live.html.heex
+++ b/lib/support/live_select_web/live/showcase_live.html.heex
@@ -72,8 +72,8 @@
               {checkbox(@settings_form, :disabled, class: "toggle")}
             <% end %>
             <%= label class: "label cursor-pointer" do %>
-              <span class="label-text mr-1">Custom option HTML:&nbsp;</span>
-              <%= checkbox(@settings_form, :custom_option_html, class: "toggle") %>
+              <span class="label-text mr-1">Options styles as checkboxes:&nbsp;</span>
+              <%= checkbox(@settings_form, :options_styled_as_checkboxes, class: "toggle") %>
             <% end %>
           </div>
           <div class="form-control max-w-sm">
@@ -292,7 +292,7 @@
                 {live_select_assigns(@settings_form.source)}
               >
                 <:option :let={%{label: label, value: _value, selected: selected}}>
-                  <%= if @settings_form[:custom_option_html].value do %>
+                  <%= if @settings_form[:options_styled_as_checkboxes].value do %>
                     <div class="flex justify-content items-center">
                       <input
                         class="rounded w-4 h-4 mr-3 border border-border"
@@ -346,7 +346,7 @@
           </button>
         </div>
         <Render.live_select
-          custom_option_html={@settings_form[:custom_option_html].value}
+          options_styled_as_checkboxes={@settings_form[:options_styled_as_checkboxes].value}
           opts={Settings.live_select_opts(@settings_form.data, true)}
         />
       </div>

--- a/test/live_select/component_test.exs
+++ b/test/live_select/component_test.exs
@@ -427,7 +427,7 @@ defmodule LiveSelect.ComponentTest do
   test "raises if unknown mode is given", %{form: form} do
     assert_raise(
       RuntimeError,
-      ~s(Invalid mode: "not_a_valid_mode". Mode must be one of: [:single, :tags]),
+      ~s(Invalid mode: "not_a_valid_mode". Mode must be one of: [:single, :tags, :quick_tags]),
       fn ->
         render_component(&LiveSelect.live_select/1,
           field: form[:input],
@@ -537,6 +537,11 @@ defmodule LiveSelect.ComponentTest do
     assert Floki.attribute(component, selectors()[:text_input], "class") == [
              "class_1 class_2"
            ]
+  end
+
+  describe "in quick_tags mode" do
+    test "" do
+    end
   end
 
   for style <- [:daisyui, :tailwind, :none, nil] do

--- a/test/live_select/component_test.exs
+++ b/test/live_select/component_test.exs
@@ -539,11 +539,6 @@ defmodule LiveSelect.ComponentTest do
            ]
   end
 
-  describe "in quick_tags mode" do
-    test "" do
-    end
-  end
-
   for style <- [:daisyui, :tailwind, :none, nil] do
     @style style
 

--- a/test/live_select_quick_tags_test.exs
+++ b/test/live_select_quick_tags_test.exs
@@ -1,0 +1,534 @@
+defmodule LiveSelectQuickTagsTest do
+  @moduledoc false
+
+  use LiveSelectWeb.ConnCase, async: true
+
+  import LiveSelect.TestHelpers
+
+  setup %{conn: conn} do
+    {:ok, live, _html} = live(conn, "/?mode=quick_tags")
+
+    %{live: live}
+  end
+
+  test "can select multiple options", %{live: live} do
+    stub_options(~w(A B C D))
+
+    type(live, "ABC")
+
+    select_nth_option(live, 2, method: :key)
+
+    type(live, "ABC")
+
+    select_nth_option(live, 4, method: :click)
+
+    assert_selected_multiple(live, ~w(B D))
+  end
+
+  test "already selected options are selectable in the dropdown using keyboard", %{live: live} do
+    stub_options(~w(A B C D))
+
+    type(live, "ABC")
+
+    select_nth_option(live, 2)
+
+    type(live, "ABC")
+    navigate(live, 2, :down)
+    keydown(live, "Enter")
+
+    assert_selected_multiple(live, ~w())
+
+    type(live, "ABC")
+    navigate(live, 10, :down)
+    navigate(live, 10, :up)
+    keydown(live, "Enter")
+  end
+
+  test "already selected options are selectable in the dropdown using mouseclick", %{
+    live: live
+  } do
+    select_and_open_dropdown(live, 2)
+
+    assert_selected_multiple(live, ~w(B))
+
+    select_nth_option(live, 2, method: :click)
+
+    assert_selected_multiple(live, ~w())
+  end
+
+  test "hitting enter with only one option selects it", %{live: live} do
+    stub_options(~w(A))
+
+    type(live, "ABC")
+
+    keydown(live, "Enter")
+
+    assert_selected_multiple(live, ~w(A))
+  end
+
+  test "hitting enter with more than one option does not select", %{live: live} do
+    stub_options(~w(A B))
+
+    type(live, "ABC")
+
+    keydown(live, "Enter")
+
+    assert_selected_multiple_static(live, [])
+  end
+
+  test "hitting enter with only one option does not select it if already selected", %{live: live} do
+    stub_options(~w(A))
+
+    type(live, "ABC")
+
+    select_nth_option(live, 1)
+
+    assert_selected_multiple(live, ~w(A))
+
+    type(live, "ABC")
+
+    keydown(live, "Enter")
+
+    assert_selected_multiple_static(live, ~w(A))
+  end
+
+  describe "when user_defined_options = true" do
+    setup %{conn: conn} do
+      {:ok, live, _html} = live(conn, "/?mode=tags&user_defined_options=true&update_min_len=3")
+      %{live: live}
+    end
+
+    test "hitting enter adds entered text to selection", %{live: live} do
+      stub_options(["A", "B"])
+
+      type(live, "ABC")
+
+      keydown(live, "Enter")
+
+      assert_selected_multiple(live, ["ABC"])
+    end
+
+    test "hitting enter does not add text to selection if element with same label is already selected",
+         %{live: live} do
+      stub_options(["ABC", "DEF"])
+
+      type(live, "ABC")
+
+      select_nth_option(live, 1, method: :key)
+
+      assert_selected_multiple(live, ["ABC"])
+
+      type(live, "ABC")
+
+      assert_options(live, ["ABC", "DEF"])
+
+      keydown(live, "Enter")
+
+      assert_selected_multiple_static(live, ["ABC"])
+    end
+
+    test "hitting enter adds text to selection even if there is only one available option", %{
+      live: live
+    } do
+      stub_options(["A"])
+
+      type(live, "ABC")
+
+      keydown(live, "Enter")
+
+      assert_selected_multiple(live, ["ABC"])
+    end
+
+    test "text added to selection should be trimmed", %{live: live} do
+      stub_options([])
+
+      type(live, "  ABC ")
+
+      keydown(live, "Enter")
+
+      assert_selected_multiple_static(live, ["ABC"])
+    end
+
+    test "text with only whitespace is ignored and not added to selection", %{live: live} do
+      stub_options(["ABC"])
+
+      type(live, "    ")
+
+      keydown(live, "Enter")
+
+      assert_selected_multiple_static(live, [])
+    end
+
+    test "text shorter than update_min_len is ignored and not added to selection", %{live: live} do
+      stub_options([{"ABC", 1}, {"DEF", 2}])
+
+      type(live, "AB")
+
+      keydown(live, "Enter")
+
+      assert_selected_multiple_static(live, [])
+    end
+
+    test "hitting enter while options are awaiting update does not select", %{live: live} do
+      stub_options(~w(A B C), delay_forever: true)
+
+      type(live, "ABC")
+
+      keydown(live, "Enter")
+
+      assert_selected_multiple_static(live, [])
+    end
+
+    test "one can still select options from the dropdown", %{live: live} do
+      stub_options(~w(A B C))
+
+      type(live, "ABC")
+
+      select_nth_option(live, 1, method: :key)
+
+      type(live, "ABC")
+
+      select_nth_option(live, 2, method: :click)
+
+      assert_selected_multiple(live, ~w(A B))
+    end
+  end
+
+  describe "when max_selectable option is set" do
+    setup %{conn: conn} do
+      {:ok, live, _html} = live(conn, "/?mode=tags&max_selectable=2")
+
+      %{live: live}
+    end
+
+    test "prevents selection of more than max_selectable options", %{live: live} do
+      stub_options(~w(A B C D))
+
+      type(live, "ABC")
+
+      select_nth_option(live, 2, method: :key)
+
+      type(live, "ABC")
+
+      select_nth_option(live, 4, method: :click)
+
+      assert_selected_multiple(live, ~w(B D))
+
+      type(live, "ABC")
+
+      select_nth_option(live, 3, method: :click)
+
+      assert_selected_multiple_static(live, ~w(B D))
+    end
+  end
+
+  test "can remove selected options by clicking on tag", %{live: live} do
+    stub_options(~w(A B C D))
+
+    type(live, "ABC")
+
+    select_nth_option(live, 2)
+
+    type(live, "ABC")
+
+    select_nth_option(live, 3)
+
+    type(live, "ABC")
+
+    select_nth_option(live, 1)
+
+    assert_selected_multiple(live, ~w(B C A))
+
+    unselect_nth_option(live, 2)
+
+    assert_selected_multiple(live, ~w(B A))
+  end
+
+  test "can set an option as sticky so it can't be removed", %{live: live} do
+    options =
+      [
+        %{tag_label: "R", value: "Rome", sticky: true},
+        %{tag_label: "NY", value: "New York"}
+      ]
+      |> Enum.sort()
+
+    sticky_pos =
+      Enum.find_index(options, & &1[:sticky]) + 1
+
+    stub_options(options)
+
+    type(live, "ABC")
+
+    select_nth_option(live, 1)
+
+    type(live, "ABC")
+
+    select_nth_option(live, 2)
+
+    refute_option_removable(live, sticky_pos)
+
+    assert_option_removable(live, 3 - sticky_pos)
+  end
+
+  test "can specify alternative labels for tags using maps", %{live: live} do
+    options =
+      [%{tag_label: "R", value: "Rome"}, %{tag_label: "NY", value: "New York"}] |> Enum.sort()
+
+    stub_options(options)
+
+    type(live, "ABC")
+
+    select_nth_option(live, 1)
+
+    type(live, "ABC")
+
+    select_nth_option(live, 2)
+
+    assert_selected_multiple(live, options |> Enum.map(&Map.put(&1, :label, &1.value)))
+  end
+
+  test "can specify alternative labels for tags using keywords", %{live: live} do
+    options =
+      [[tag_label: "R", value: "Rome"], [tag_label: "NY", value: "New York"]] |> Enum.sort()
+
+    stub_options(options)
+
+    type(live, "ABC")
+
+    select_nth_option(live, 1)
+
+    type(live, "ABC")
+
+    select_nth_option(live, 2)
+
+    selection =
+      options
+      |> Enum.map(&Map.new/1)
+      |> Enum.map(&Map.put(&1, :label, &1[:value]))
+
+    assert_selected_multiple(live, selection)
+  end
+
+  test "can be disabled", %{conn: conn} do
+    {:ok, live, _html} = live(conn, "/?disabled=true&mode=tags")
+
+    assert element(live, selectors()[:text_input])
+           |> render()
+           |> Floki.parse_fragment!()
+           |> Floki.attribute("disabled") == ["disabled"]
+  end
+
+  test "can clear the selection", %{conn: conn} do
+    {:ok, live, _html} = live(conn, "/?mode=tags")
+
+    stub_options(~w(A B C D))
+
+    type(live, "ABC")
+
+    select_nth_option(live, 1)
+
+    type(live, "ABC")
+
+    select_nth_option(live, 2, method: :click)
+
+    assert_selected_multiple(live, ~w(A B))
+
+    send_update(live, value: nil)
+
+    assert_selected_multiple(live, [])
+  end
+
+  test "can force the selection", %{conn: conn} do
+    {:ok, live, _html} = live(conn, "/?mode=tags")
+
+    stub_options(~w(A B C D))
+
+    type(live, "ABC")
+
+    select_nth_option(live, 1)
+
+    type(live, "ABC")
+
+    select_nth_option(live, 2, method: :click)
+
+    assert_selected_multiple(live, ~w(A B))
+
+    send_update(live, value: ~w(B C))
+
+    assert_selected_multiple(live, ~w(B C))
+  end
+
+  test "can force the selection and options", %{conn: conn} do
+    {:ok, live, _html} = live(conn, "/?mode=tags")
+
+    stub_options(~w(A B C D))
+
+    type(live, "ABC")
+
+    select_nth_option(live, 1)
+
+    type(live, "ABC")
+
+    select_nth_option(live, 2, method: :click)
+
+    assert_selected_multiple(live, ~w(A B))
+
+    send_update(live, value: [3, 5], options: [{"C", 3}, {"D", 4}, {"E", 5}])
+
+    assert_selected_multiple(live, [%{label: "C", value: 3}, %{label: "E", value: 5}])
+  end
+
+  test "can render custom clear button", %{conn: conn} do
+    {:ok, live, _html} = live(conn, "/live_component_test")
+
+    type(live, "Ber",
+      component: "#my_form_city_search_custom_clear_tags_live_select_component",
+      parent: "#form_component"
+    )
+
+    select_nth_option(live, 1,
+      component: "#my_form_city_search_custom_clear_tags_live_select_component"
+    )
+
+    assert element(
+             live,
+             "#my_form_city_search_custom_clear_tags_live_select_component button[data-idx=0]",
+             "custom clear button"
+           )
+           |> has_element?
+  end
+
+  defp select_and_open_dropdown(live, pos) do
+    if pos < 1 || pos > 4, do: raise("pos must be between 1 and 4")
+
+    stub_options(~w(A B C D))
+
+    type(live, "ABC")
+
+    select_nth_option(live, 2)
+
+    type(live, "ABC")
+
+    :ok
+  end
+
+  describe "when focus and blur events are set" do
+    setup %{conn: conn} do
+      {:ok, live, _html} =
+        live(conn, "/?phx-focus=focus-event-for-parent&phx-blur=blur-event-for-parent&mode=tags")
+
+      %{live: live}
+    end
+
+    test "focusing on the input field sends a focus event to the parent", %{live: live} do
+      element(live, selectors()[:text_input])
+      |> render_focus()
+
+      assert_push_event(live, "parent_event", %{
+        id: "my_form_city_search_live_select_component",
+        event: "focus-event-for-parent",
+        payload: %{id: "my_form_city_search_live_select_component"}
+      })
+    end
+
+    test "blurring the input field sends a blur event to the parent", %{live: live} do
+      element(live, selectors()[:text_input])
+      |> render_blur()
+
+      assert_push_event(live, "select", %{
+        id: "my_form_city_search_live_select_component",
+        parent_event: "blur-event-for-parent"
+      })
+    end
+
+    test "selecting option with enter doesn't send blur event to parent", %{conn: conn} do
+      stub_options([{"A", 1}, {"B", 2}, {"C", 3}])
+
+      {:ok, live, _html} = live(conn, "/?phx-blur=blur-event-for-parent&mode=tags")
+
+      type(live, "ABC")
+
+      assert_options(live, ["A", "B", "C"])
+
+      select_nth_option(live, 2, method: :key)
+
+      refute_push_event(live, "select", %{
+        id: "my_form_city_search_live_select_component",
+        parent_event: "blur-event-for-parent"
+      })
+    end
+
+    test "selecting option with click doesn't send blur event to parent", %{conn: conn} do
+      stub_options([{"A", 1}, {"B", 2}, {"C", 3}])
+
+      {:ok, live, _html} = live(conn, "/?phx-blur=blur-event-for-parent&mode=tags")
+
+      type(live, "ABC")
+
+      assert_options(live, ["A", "B", "C"])
+
+      select_nth_option(live, 2, method: :click)
+
+      refute_push_event(live, "select", %{
+        id: "my_form_city_search_live_select_component",
+        parent_event: "blur-event-for-parent"
+      })
+    end
+  end
+
+  test "selection can be updated from the form", %{conn: conn} do
+    stub_options(%{
+      "A" => 1,
+      "B" => 2,
+      "C" => 3
+    })
+
+    {:ok, live, _html} = live(conn, "/?mode=tags")
+
+    type(live, "ABC")
+
+    select_nth_option(live, 1)
+
+    type(live, "ABC")
+
+    select_nth_option(live, 2, method: :click)
+
+    stub_options(%{"D" => 4, "E" => 5})
+
+    type(live, "DEE")
+
+    select_nth_option(live, 1)
+
+    render_change(live, "change", %{"my_form" => %{"city_search" => [1, 2, 4]}})
+
+    assert_selected_multiple(live, [
+      %{value: 1, label: "A"},
+      %{value: 2, label: "B"},
+      %{value: 4, label: "D"}
+    ])
+  end
+
+  test "selection recovery", %{conn: conn} do
+    {:ok, live, _html} = live(conn, "/?mode=tags")
+
+    values = [
+      value1 = %{"name" => "A", "pos" => [10.0, 20.0]},
+      value2 = %{"name" => "B", "pos" => [30.0, 40.0]},
+      value3 = %{"name" => "C", "pos" => [50.0, 60.0]}
+    ]
+
+    render_change(live, "change", %{"my_form" => %{"city_search" => Jason.encode!(values)}})
+
+    render_hook(element(live, selectors()[:container]), "selection_recovery", [
+      %{label: "A", value: value1},
+      %{label: "B", value: value2},
+      %{label: "C", value: value3}
+    ])
+
+    assert_selected_multiple_static(live, [
+      %{label: "A", value: value1},
+      %{label: "B", value: value2},
+      %{label: "C", value: value3}
+    ])
+  end
+end

--- a/test/live_select_quick_tags_test.exs
+++ b/test/live_select_quick_tags_test.exs
@@ -25,26 +25,23 @@ defmodule LiveSelectQuickTagsTest do
     assert_selected_multiple(live, ~w(B D))
   end
 
-  test "already selected options are selectable in the dropdown using keyboard", %{live: live} do
+  test "already selected options can be deselected in the dropdown using keyboard", %{live: live} do
     stub_options(~w(A B C D))
 
     type(live, "ABC")
 
     select_nth_option(live, 2)
+    assert_selected_multiple(live, ~w(B))
 
     type(live, "ABC")
-    navigate(live, 2, :down)
-    keydown(live, "Enter")
+    navigate(live, 3, :down)
+    navigate(live, 1, :up)
 
+    keydown(live, "Enter")
     assert_selected_multiple(live, ~w())
-
-    type(live, "ABC")
-    navigate(live, 10, :down)
-    navigate(live, 10, :up)
-    keydown(live, "Enter")
   end
 
-  test "already selected options are selectable in the dropdown using mouseclick", %{
+  test "already selected options can be deselected in the dropdown using mouseclick", %{
     live: live
   } do
     select_and_open_dropdown(live, 2)


### PR DESCRIPTION
Hi! 😄

This is a suggestion for a new variant of the tag mode. The multiple_select option for the new tags_mode attribute makes it possible to select multiple options quickly without needing to search or force the dropdown to appear. The current tag mode hides the dropdown-part when a option is selected. This approach could probably be described as a kind hybrid of the normal live_select tag mode and a normal multi select input.

A new attribute `tags_mode` is added with `:default` (how tags work today) and `:multiple_select` as possible options.

Example usage taken from demo-app:
```heex
<.live_select
   field={my_form[:city_search]}
   selected_option_class="cursor-pointer font-bold hover:bg-gray-400 rounded"
   mode={:tags}
   tags_mode={:multiple_select}
   placeholder="Search for a city"
   update_min_len={3} />
``` 

There is some code in the demo app related to selected_option_class as this feature would need some new style defaults/style changes to look passable out of the box. This should probably be solved some other way. Maybe by adding some new default styles.

The name chosen, multiple_select, is very much up for debate. I just needed something to work with.

### Potential performance issue

When testing in the demo app I do notice some slowness when selecting or deselecting many options in rapid succession. I did not experience this in our app. I am not sure if this is a flaw in the implementation or just that the dataset for the demo app is very large. Any suggestions on this point is especially welcome.

### Breaking changes

The feature also changes the value exposed to the option-slot to also return an indication if the option is already selected. This is one of the main points of the change as the impetus for this feature is a design/UX that displays the selected with a checkbox. See attached picture for example. I suppose this could be done with just styles but the design seems harder to replicate that way and I also think it would be nice to be able to have that info available to the slot. But still open for debate. :)

**Example of option-slot usage:** 
Notice the :let now exposing a tuple which contains the option and a selected boolean.

```heex
<:option :let={{%{label: label, value: value}, selected}}>
  <div class="flex justify-content items-center">
    <input
      class="rounded w-4 h-4 mr-3 border border-border"
      type="checkbox"
      checked={selected}
    />
    <span class="text-sm"><%= label %></span>
  </div>
</:option>
```
**Rendered example:**
![image](https://github.com/user-attachments/assets/1f32ebe7-7192-4d48-8723-b9e0262b03df)

This is a suggestion based on functionality that we where in need of and I hope it can be added to the project in some form.

This is not expected to be merged as-is (ex. tests is missing for now) but it is working code that we would use in our fork and a good point to discuss from I think.

I'm aware that this might not be something that this project wants and I'm happy to make changes or discuss the approach. Maybe there is a better way to achive the same or something very similar?

The changes necessary does not seem to invasive though from my perspective (except maybe the option-slot breaking change 😅).

Let me know what you think. 😄 

EDIT: I forgot while writing this, but there is also a bug in this implementation I have not figured out. When making the first selection the blur event triggers and hides the dropdown. This does not happen on other selections but consistently happens from state of nothing selected to first option selected.