### PR TITLE
Fix typos again

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 **LiveSelect and LiveView versions**
 have you tried LiveSelect's and LiveView's latest versions? Please try them and see if the bug still occur
-which LiveSelect version are you on? (`mix deps | grep live_selct`)
+which LiveSelect version are you on? (`mix deps | grep live_select`)
 which LiveView version are you on? (`mix deps | grep phoenix_live_view`)
 
 **Describe the bug**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ do not restore selection after blur it it was cleard by hitting the clear button
 
 ## 1.4.0 (2024-03-18)
 
-* support for assocations and embeds
+* support for associations and embeds
 * add `value_mapper` assign and `decode/1` function
 
 ## 1.3.3 (2024-02-06)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ interface for search-like functionalities with type-ahead. `LiveSelect`s feature
 
 * Single as well as multiple selection
 * Options to configure the behaviour, such as minimum number of characters that trigger an update or the maximum number of selectable options
-* Default styles for daisyUI and tailwindcss, which are fully customizable and can be completely overriden if needed
+* Default styles for daisyUI and tailwindcss, which are fully customizable and can be completely overridden if needed
 * Ability to customize the rendered HTML for dropdown entries and tags using slots.
 
 ### [Try it in the showcase app](https://live-select.fly.dev/) 🔬

--- a/test/live_select_tags_test.exs
+++ b/test/live_select_tags_test.exs
@@ -266,9 +266,9 @@ defmodule LiveSelectTagsTest do
 
     select_nth_option(live, 2)
 
-    refute_option_removeable(live, sticky_pos)
+    refute_option_removable(live, sticky_pos)
 
-    assert_option_removeable(live, 3 - sticky_pos)
+    assert_option_removable(live, 3 - sticky_pos)
   end
 
   test "can specify alternative labels for tags using maps", %{live: live} do

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -405,13 +405,13 @@ defmodule LiveSelect.TestHelpers do
            |> Floki.attribute("value") == []
   end
 
-  def assert_option_removeable(live, n) do
+  def assert_option_removable(live, n) do
     selector = "#{@selectors[:tags_container]} button[data-idx=#{n - 1}]"
 
     assert has_element?(live, selector)
   end
 
-  def refute_option_removeable(live, n) do
+  def refute_option_removable(live, n) do
     selector = "#{@selectors[:tags_container]} button[data-idx=#{n - 1}]"
 
     refute has_element?(live, selector)


### PR DESCRIPTION
Found via `typos --hidden --format brief`