### PR TITLE
fix: use common encode function across libraries

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -25,6 +25,9 @@ jobs:
           - elixir: '1.17'
             otp: '27'
             lint: true
+          - elixir: '1.18'
+            otp: '27'
+            lint: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/config/config.exs
+++ b/config/config.exs
@@ -53,9 +53,6 @@ config :tailwind,
     cd: Path.expand("../assets", __DIR__)
   ]
 
-# Use Jason for JSON parsing in Phoenix
-config :phoenix, :json_library, Jason
-
 config :mix, colors: [enabled: true]
 
 # Import environment specific config. This must remain at the bottom

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -23,6 +23,17 @@ end
 port = String.to_integer(System.get_env("PORT") || "4000")
 config :live_select, LiveSelectWeb.Endpoint, http: [port: port]
 
+current_semver = Version.parse!(System.version())
+min_semver = %Version{major: 1, minor: 18, patch: 0}
+
+if Version.compare(current_semver, min_semver) == :lt do
+  # Use Jason for JSON parsing in Phoenix
+  config :phoenix, :json_library, Jason
+else
+  # Use built-in JSON module for JSON parsing in Phoenix
+  config :phoenix, :json_library, JSON
+end
+
 if config_env() == :demo do
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -241,7 +241,7 @@ defmodule LiveSelect.Component do
        selection:
          Enum.map(socket.assigns.selection, fn %{value: value} ->
            Enum.find(options, fn %{value: option_value} ->
-             json.encode(option_value) == json.encode(value)
+             json.encode!(option_value) == json.encode!(value)
            end)
          end)
          |> Enum.filter(& &1)


### PR DESCRIPTION
Ensure that we call a version of encode that exists for both the Jason library, and new builtin JSON module.

Fixes #98