### PR TITLE
Restore current_text on blur/focus in tags mode.

### DIFF
--- a/assets/js/live_select.js
+++ b/assets/js/live_select.js
@@ -91,10 +91,7 @@ export default {
             this.handleEvent("select", ({id, selection, mode, current_text, input_event, parent_event}) => {
                 if (this.el.id === id) {
                     this.selection = selection
-                    if (mode === "single") {
-                        const label = selection.length > 0 ? selection[0].label : null
-                        this.setInputValue(label)
-                    } else if (mode === "tags") {
+                    if (mode === "single" || mode === "tags") {
                         this.setInputValue(current_text)
                     } else {
                         this.setInputValue(null)

--- a/assets/js/live_select.js
+++ b/assets/js/live_select.js
@@ -88,12 +88,14 @@ export default {
                     this.pushEventToParent(event, payload)
                 }
             })
-            this.handleEvent("select", ({id, selection, mode, input_event, parent_event}) => {
+            this.handleEvent("select", ({id, selection, mode, current_text, input_event, parent_event}) => {
                 if (this.el.id === id) {
                     this.selection = selection
                     if (mode === "single") {
                         const label = selection.length > 0 ? selection[0].label : null
                         this.setInputValue(label)
+                    } else if (mode === "tags") {
+                        this.setInputValue(current_text)
                     } else {
                         this.setInputValue(null)
                     }

--- a/assets/js/live_select.js
+++ b/assets/js/live_select.js
@@ -91,7 +91,10 @@ export default {
             this.handleEvent("select", ({id, selection, mode, current_text, input_event, parent_event}) => {
                 if (this.el.id === id) {
                     this.selection = selection
-                    if (mode === "single" || mode === "tags") {
+                    if (mode === "single") {
+                        const label = selection.length > 0 ? selection[0].label : current_text
+                        this.setInputValue(label)
+                    } else if (mode === "tags") {
                         this.setInputValue(current_text)
                     } else {
                         this.setInputValue(null)

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -19,6 +19,7 @@ defmodule LiveSelect.Component do
     clear_button_extra_class: nil,
     clear_tag_button_class: nil,
     clear_tag_button_extra_class: nil,
+    current_text: nil,
     user_defined_options: false,
     container_class: nil,
     container_extra_class: nil,
@@ -518,6 +519,7 @@ defmodule LiveSelect.Component do
       %{
         id: socket.assigns.id,
         mode: socket.assigns.mode,
+        current_text: socket.assigns.current_text,
         selection: socket.assigns.selection,
         parent_event: parent_event
       }


### PR DESCRIPTION
When in `tags` mode if you type something into the text field, focus your cursor out of the component and then back into it, then it gets into a weird state. The text that you've typed into the input disappears when your blur, but when you focus again the selections remain as they were before the blur (so that the user needs to type something and then backspace it away in order to reset the selections).

This PR takes the approach of maintaining the current text in the input field when blurring the cursor away from it.

Here's a clip demonstrating the bug:

https://github.com/user-attachments/assets/7b19998b-78ee-47c2-8b85-d20eb8f36a32

Here's a clip demonstrating with this PR:

https://github.com/user-attachments/assets/1e1bf4dd-3b8d-45a5-9dc1-6d2d44083cb2

