### PR TITLE
Add "disable tag removal" setting

### DIFF
--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -407,6 +407,8 @@ defmodule LiveSelect do
 
   attr :disabled, :boolean, doc: "set this to `true` to disable the input field"
 
+  attr :disable_tag_removal, :boolean, doc: "set this to `true` to disable the ability to remove tags"
+
   attr :placeholder, :string, doc: "placeholder text for the input field"
 
   attr :debounce, :integer,

--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -407,7 +407,8 @@ defmodule LiveSelect do
 
   attr :disabled, :boolean, doc: "set this to `true` to disable the input field"
 
-  attr :disable_tag_removal, :boolean, doc: "set this to `true` to disable the ability to remove tags"
+  attr :disable_tag_removal, :boolean,
+    doc: "set this to `true` to disable the ability to remove tags"
 
   attr :placeholder, :string, doc: "placeholder text for the input field"
 

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -318,6 +318,7 @@ defmodule LiveSelect.Component do
   @impl true
   def handle_event("clear", _params, socket) do
     if socket.assigns.disable_tag_removal, do: raise("Forbidden")
+
     socket =
       socket
       |> assign(last_selection: nil)

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -311,13 +311,13 @@ defmodule LiveSelect.Component do
 
   @impl true
   def handle_event("option_remove", %{"idx" => idx}, socket) do
-    if socket.assigns.disable_tag_removal, do: raise "Forbidden"
+    if socket.assigns.disable_tag_removal, do: raise("Forbidden")
     {:noreply, unselect(socket, String.to_integer(idx))}
   end
 
   @impl true
   def handle_event("clear", _params, socket) do
-    if socket.assigns.disable_tag_removal, do: raise "Forbidden"
+    if socket.assigns.disable_tag_removal, do: raise("Forbidden")
     socket =
       socket
       |> assign(last_selection: nil)

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -24,6 +24,7 @@ defmodule LiveSelect.Component do
     container_extra_class: nil,
     debounce: 100,
     disabled: false,
+    disable_tag_removal: false,
     dropdown_class: nil,
     dropdown_extra_class: nil,
     max_selectable: 0,
@@ -310,11 +311,13 @@ defmodule LiveSelect.Component do
 
   @impl true
   def handle_event("option_remove", %{"idx" => idx}, socket) do
+    if socket.assigns.disable_tag_removal, do: raise "Forbidden"
     {:noreply, unselect(socket, String.to_integer(idx))}
   end
 
   @impl true
   def handle_event("clear", _params, socket) do
+    if socket.assigns.disable_tag_removal, do: raise "Forbidden"
     socket =
       socket
       |> assign(last_selection: nil)

--- a/lib/live_select/component.html.heex
+++ b/lib/live_select/component.html.heex
@@ -15,7 +15,7 @@
           <%= if @tag == [] do %>
             <%= option[:tag_label] || option[:label] %>
           <% else %>
-            <%= render_slot(@tag, Map.put(option, :field, @field)) %>
+            <%= render_slot(@tag, option) %>
           <% end %>
           <button
             :if={!option[:sticky] && !@disable_tag_removal}

--- a/lib/live_select/component.html.heex
+++ b/lib/live_select/component.html.heex
@@ -15,10 +15,10 @@
           <%= if @tag == [] do %>
             <%= option[:tag_label] || option[:label] %>
           <% else %>
-            <%= render_slot(@tag, option) %>
+            <%= render_slot(@tag, Map.put(option, :field, @field)) %>
           <% end %>
           <button
-            :if={!option[:sticky]}
+            :if={!option[:sticky] && !@disable_tag_removal}
             type="button"
             data-idx={idx}
             class={


### PR DESCRIPTION
This adds a new component setting which allows to disable removal of currently selected tags. With this setting on one can implement "read only" forms.

Currently LS has "sticky" attribute for options but its purpose is to lock a single option, and I couldn't make it work well with assocs/embeds - it's honestly too much work if all you need is "read only" mode. Besides, this new option prevents removal on the event callback level too.
