### PR TITLE
Allow individual options to be disabled

### DIFF
--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -57,6 +57,9 @@ defmodule LiveSelect do
   * _maps_: `%{label: label, value: value}` or `%{value: value}`
   * _keywords_: `[label: label, value: value]` or `[value: value]`
 
+  Options can also be disabled when passing in tuples, maps or keywords. Disabled options are displayed, but can't be selected.
+  Maps and keywords need a `:disabled` key with a boolean value, and tuples should be a 3 element tuple of `{label, value, is_disabled}`
+
   In the case of maps and keywords, if only `value` is specified, it will be used as both value and label for the option.
 
   Because you can pass a list of tuples, you can use maps and keyword lists to pass the list of options, for example:

--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -449,7 +449,7 @@ defmodule LiveSelect do
     doc:
       "Event to emit when the text input receives focus. The component id will be sent in the event's params"
 
-  @styling_options ~w(active_option_class available_option_class clear_button_class clear_button_extra_class clear_tag_button_class clear_tag_button_extra_class container_class container_extra_class dropdown_class dropdown_extra_class option_class option_extra_class text_input_class text_input_extra_class text_input_selected_class selected_option_class tag_class tag_extra_class tags_container_class tags_container_extra_class)a
+  @styling_options ~w(active_option_class available_option_class unavailable_option_class clear_button_class clear_button_extra_class clear_tag_button_class clear_tag_button_extra_class container_class container_extra_class dropdown_class dropdown_extra_class option_class option_extra_class text_input_class text_input_extra_class text_input_selected_class selected_option_class tag_class tag_extra_class tags_container_class tags_container_extra_class)a
 
   for attr_name <- @styling_options do
     Phoenix.Component.Declarative.__attr__!(

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -593,6 +593,41 @@ defmodule LiveSelect.Component do
     )
   end
 
+  defp normalize_option(option) when is_list(option) do
+    if Keyword.keyword?(option) do
+      Map.new(option)
+      |> normalize_option()
+    else
+      :error
+    end
+  end
+
+  defp normalize_option(option) when is_map(option) do
+    case option do
+      %{key: key, value: _value} = option ->
+        {:ok, Enum.into(option, %{label: key, disabled: false})}
+
+      %{value: value} = option ->
+        {:ok, Enum.into(option, %{label: value, disabled: false})}
+
+      _ ->
+        :error
+    end
+  end
+
+  defp normalize_option(option) when is_tuple(option) do
+    case option do
+      {label, value} ->
+        {:ok, %{label: label, value: value, disabled: false}}
+
+      {label, value, disabled} ->
+        {:ok, %{label: label, value: value, disabled: disabled}}
+
+      _ ->
+        :error
+    end
+  end
+
   defp normalize_option(option) do
     case option do
       nil ->
@@ -600,20 +635,6 @@ defmodule LiveSelect.Component do
 
       "" ->
         {:ok, nil}
-
-      %{key: key, value: _value} = option ->
-        {:ok, Map.put_new(option, :label, key) |> Map.put_new(:disabled, false)}
-
-      %{value: value} = option ->
-        {:ok, Map.put_new(option, :label, value) |> Map.put_new(:disabled, false)}
-
-      option when is_list(option) ->
-        if Keyword.keyword?(option) do
-          Map.new(option)
-          |> normalize_option()
-        else
-          :error
-        end
 
       option when is_binary(option) or is_atom(option) or is_number(option) ->
         {:ok, %{label: option, value: option, disabled: false}}

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -448,6 +448,14 @@ defmodule LiveSelect.Component do
   end
 
   defp select(
+         socket,
+         %{disabled: true} = _selected,
+         _extra_params
+       ) do
+    assign(socket, hide_dropdown: not quick_tags_mode?(socket))
+  end
+
+  defp select(
          %{assigns: %{selection: selection, max_selectable: max_selectable}} = socket,
          _selected,
          _extra_params
@@ -594,10 +602,10 @@ defmodule LiveSelect.Component do
         {:ok, nil}
 
       %{key: key, value: _value} = option ->
-        {:ok, Map.put_new(option, :label, key)}
+        {:ok, Map.put_new(option, :label, key) |> Map.put_new(:disabled, false)}
 
       %{value: value} = option ->
-        {:ok, Map.put_new(option, :label, value)}
+        {:ok, Map.put_new(option, :label, value) |> Map.put_new(:disabled, false)}
 
       option when is_list(option) ->
         if Keyword.keyword?(option) do
@@ -607,11 +615,8 @@ defmodule LiveSelect.Component do
           :error
         end
 
-      {label, value} ->
-        {:ok, %{label: label, value: value}}
-
       option when is_binary(option) or is_atom(option) or is_number(option) ->
-        {:ok, %{label: option, value: option}}
+        {:ok, %{label: option, value: option, disabled: false}}
 
       _ ->
         :error

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -737,7 +737,8 @@ defmodule LiveSelect.Component do
     options
     |> Enum.with_index()
     |> Enum.reject(fn {opt, _} ->
-      active_option == opt || (mode != :quick_tags && already_selected?(opt, selection))
+      active_option == opt || (mode != :quick_tags && already_selected?(opt, selection)) ||
+        Map.get(opt, :disabled)
     end)
     |> Enum.map(fn {_, idx} -> idx end)
     |> Enum.find(active_option, &(&1 > active_option))
@@ -762,7 +763,8 @@ defmodule LiveSelect.Component do
     |> Enum.with_index()
     |> Enum.reverse()
     |> Enum.reject(fn {opt, _} ->
-      active_option == opt || (mode != :quick_tags && already_selected?(opt, selection))
+      active_option == opt || (mode != :quick_tags && already_selected?(opt, selection)) ||
+        Map.get(opt, :disabled)
     end)
     |> Enum.map(fn {_, idx} -> idx end)
     |> Enum.find(active_option, &(&1 < active_option || active_option == -1))

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -452,7 +452,7 @@ defmodule LiveSelect.Component do
          %{disabled: true} = _selected,
          _extra_params
        ) do
-    assign(socket, hide_dropdown: not quick_tags_mode?(socket))
+    socket
   end
 
   defp select(
@@ -461,7 +461,7 @@ defmodule LiveSelect.Component do
          _extra_params
        )
        when max_selectable > 0 and length(selection) >= max_selectable do
-    assign(socket, hide_dropdown: not quick_tags_mode?(socket))
+    socket
   end
 
   defp select(socket, selected, extra_params) do

--- a/lib/live_select/component.html.heex
+++ b/lib/live_select/component.html.heex
@@ -107,6 +107,9 @@
       <%= for {option, idx} <- Enum.with_index(@options) do %>
         <li class={
           cond do
+            option.disabled ->
+              class(@style, :unavailable_option, @unavailable_option_class)
+
             already_selected?(option, @selection) ->
               class(@style, :selected_option, @selected_option_class)
 

--- a/test/live_select_quick_tags_test.exs
+++ b/test/live_select_quick_tags_test.exs
@@ -572,4 +572,16 @@ defmodule LiveSelectQuickTagsTest do
       %{label: "C", value: value3}
     ])
   end
+
+  test "Disabled options can't be selected", %{live: live} do
+    stub_options([{"A", 1, true}, {"B", 2, false}, {"C", 3, false}])
+
+    type(live, "ABC")
+
+    select_nth_option(live, 1, method: :click)
+    refute_selected(live)
+
+    select_nth_option(live, 2, method: :click)
+    assert_selected_multiple(live, [%{value: 2, label: "B"}])
+  end
 end

--- a/test/live_select_tags_test.exs
+++ b/test/live_select_tags_test.exs
@@ -221,6 +221,24 @@ defmodule LiveSelectTagsTest do
 
       assert_selected_multiple_static(live, ~w(B D))
     end
+
+    test "Disabled Items stay disabled", %{live: live} do
+      stub_options([{"A", 1, true}, {"B", 2, false}, {"C", 3, false}, {"D", 4, false}])
+
+      type(live, "ABC")
+      select_nth_option(live, 2, method: :click)
+
+      type(live, "ABC")
+      select_nth_option(live, 3, method: :click)
+      assert_selected_multiple(live, [%{value: 2, label: "B"}, %{value: 3, label: "C"}])
+
+      unselect_nth_option(live, 2)
+      assert_selected_multiple(live, [%{value: 2, label: "B"}])
+
+      type(live, "ABC")
+      select_nth_option(live, 1, method: :click)
+      assert_selected_multiple(live, [%{value: 2, label: "B"}])
+    end
   end
 
   test "can remove selected options by clicking on tag", %{live: live} do
@@ -547,5 +565,17 @@ defmodule LiveSelectTagsTest do
       %{label: "B", value: value2},
       %{label: "C", value: value3}
     ])
+  end
+
+  test "Can't select disabled options as tags", %{live: live} do
+    stub_options([{"A", 1, true}, {"B", 2, false}, {"C", 3, false}])
+
+    type(live, "ABC")
+    select_nth_option(live, 1, method: :click)
+    refute_selected(live)
+
+    type(live, "ABC")
+    select_nth_option(live, 2, method: :click)
+    assert_selected_multiple(live, [%{label: "B", value: 2}])
   end
 end

--- a/test/live_select_test.exs
+++ b/test/live_select_test.exs
@@ -991,22 +991,35 @@ defmodule LiveSelectTest do
   end
 
   describe "Disabled option tests" do
-    test "tuples options can be disabled", %{conn: conn} do
+    test "Disabled Options are skipped by keydown events", %{conn: conn} do
       stub_options([{"A", 1, false}, {"B", 2, true}, {"C", 3, false}])
 
       {:ok, live, _html} = live(conn, "/")
-      type(live, "ABC")
 
+      type(live, "ABC")
       assert_options(live, ["A", "B", "C"])
 
-      # Select an enabled option
-      select_nth_option(live, 1)
-      assert_selected(live, "A", 1)
-
-      # Key down skips the disabled Options
-      type(live, "ABC")
       select_nth_option(live, 2)
       assert_selected(live, "C", 3)
+    end
+
+    test "Disabled Options are skipped by key up events", %{conn: conn} do
+      stub_options([{"A", 1, false}, {"B", 2, true}, {"C", 3, false}])
+
+      {:ok, live, _html} = live(conn, "/")
+
+      type(live, "ABC")
+      assert_options(live, ["A", "B", "C"])
+
+      # Navigate to C by going two down
+      navigate(live, 2, :down, [])
+
+      # Navigate back to A by going 1 up as we skip B because it's disabled.
+      # Then select the item we're on. It should be "A"
+      navigate(live, 1, :up, [])
+      keydown(live, "Enter", [])
+
+      assert_selected(live, "A", 1)
     end
 
     test "Supports disabling options filled from an enumerable of maps", %{conn: conn} do

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -289,9 +289,9 @@ defmodule LiveSelect.TestHelpers do
   def normalize_selection(selection) do
     for element <- selection do
       if is_binary(element) || is_integer(element) || is_atom(element) do
-        %{value: element, label: element}
+        %{value: element, label: element, disabled: false}
       else
-        element
+        element |> Map.put_new(:disabled, false)
       end
     end
   end


### PR DESCRIPTION
Updates LiveSelect to have the ability to disable an option in `:single`, `:tags` and `:quick_tags` mode. This way an option can not be selected like a disabled option in a regular `select` tag.

<img width="534" alt="image" src="https://github.com/user-attachments/assets/df58e2c1-8118-431b-8ef7-438943d31e18" />

Clicking a disabled option will not close the options dropdown, nor select the option. This has a minor behavior change to `:tags` mode. Before clicking an option after reaching the max selectable items would close the options dropdown, but leave the input focused.

I believe this behavior change brings it closer to how clicking a disabled option would act with a `select` tag. Though if requested I can drop this change. It can also be limited if requested to only change the behavior for `:single` mode and / or `:tag` mode before the max items are selected.

Finally I included one commit to add the `unavailable_option_class` as an attribute. It seems it was missing before, so setting it on a LiveSelect would emit a warning.