### PR TITLE
Add DaisyUI 5 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Added
+* DaisyUI 5 compatibility - active options now include both `active` and `menu-active` classes for compatibility with DaisyUI 3, 4, and 5.
+
 ## 1.6.0 (2025-04-13)
 
 * add ability to disable options

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -64,7 +64,7 @@ defmodule LiveSelect.Component do
       tag: ~W(p-1 text-sm rounded-lg bg-blue-400 flex)
     ],
     daisyui: [
-      active_option: ~W(active),
+      active_option: ~W(active menu-active),
       available_option: ~W(cursor-pointer),
       unavailable_option: ~W(disabled),
       clear_button: ~W(hidden cursor-pointer),

--- a/styling.md
+++ b/styling.md
@@ -60,7 +60,7 @@ The following table shows the default styles for each element and the options yo
 
 | Element | Default daisyui classes | Default tailwind classes | Class override option | Class extend option |
 |----|----|----|----|----|
-| *active_option* | active | bg-gray-600 text-white | active_option_class |  |
+| *active_option* | active menu-active | bg-gray-600 text-white | active_option_class |  |
 | *available_option* | cursor-pointer | cursor-pointer hover:bg-gray-400 rounded | available_option_class |  |
 | *clear_button* | cursor-pointer hidden | cursor-pointer hidden | clear_button_class | clear_button_extra_class |
 | *clear_tag_button* | cursor-pointer | cursor-pointer | clear_tag_button_class | clear_tag_button_extra_class |

--- a/test/live_select/component_test.exs
+++ b/test/live_select/component_test.exs
@@ -883,6 +883,31 @@ defmodule LiveSelect.ComponentTest do
           end
         end
       end
+
+      test "daisyui style includes both active and menu-active classes for compatibility", %{
+        form: form
+      } do
+        # Render the component with daisyui style
+        component =
+          render_component(&LiveSelect.live_select/1,
+            field: form[:city_search],
+            options: ["A", "B", "C"],
+            style: :daisyui,
+            hide_dropdown: false
+          )
+          |> Floki.parse_document!()
+
+        # Find the first option div
+        option_divs = Floki.find(component, "div[data-idx]")
+        assert length(option_divs) > 0
+
+        # Get the default active option classes for daisyui
+        active_classes = LiveSelect.Component.default_class(:daisyui, :active_option)
+
+        # Verify both classes are in the defaults
+        assert "active" in active_classes
+        assert "menu-active" in active_classes
+      end
     end
   end
 end


### PR DESCRIPTION
DaisyUI 5 (as installed by default in Phoenix 1.8) has a breaking change which means that keyboard selection of elements doesn't display.

Includes the following:
- Active options now include both 'active' and 'menu-active' classes
- Maintains backward compatibility with DaisyUI 3 and 4
- Added test to verify both classes are applied
- Updated CHANGELOG to document the change