### PR TITLE
Updating to supported Github runner

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         include:


### PR DESCRIPTION
CI is failing due to an unsupported Ubuntu version, this fixes it.