### PR TITLE
Add tags_container_position option

### DIFF
--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -457,7 +457,6 @@ defmodule LiveSelect do
     doc:
       "one of `:tailwind`, `:daisyui` or `:none`. See the [Styling section](styling.html) for details"
 
-
   attr :tags_container_position, :atom,
     values: [:top, :bottom],
     default: Component.default_opts()[:tags_container_position],

--- a/lib/live_select.ex
+++ b/lib/live_select.ex
@@ -457,6 +457,13 @@ defmodule LiveSelect do
     doc:
       "one of `:tailwind`, `:daisyui` or `:none`. See the [Styling section](styling.html) for details"
 
+
+  attr :tags_container_position, :atom,
+    values: [:top, :bottom],
+    default: Component.default_opts()[:tags_container_position],
+    doc:
+      "used to set the position of the tags container. One of `:top` or `:bottom` to show the tags container at the top or bottom of the dropdown"
+
   slot(:option,
     doc:
       "optional slot that renders an option in the dropdown. The option's data is available via `:let`"

--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -41,6 +41,7 @@ defmodule LiveSelect.Component do
     tag_extra_class: nil,
     tags_container_class: nil,
     tags_container_extra_class: nil,
+    tags_container_position: :top,
     text_input_class: nil,
     text_input_extra_class: nil,
     text_input_selected_class: nil,

--- a/lib/live_select/component.html.heex
+++ b/lib/live_select/component.html.heex
@@ -8,40 +8,42 @@
   data-field={@field.id}
   data-debounce={@debounce}
 >
-<%= if @tags_container_position == :top do %>
-  <div class={class(@style, :tags_container, @tags_container_class, @tags_container_extra_class)}>
-    <%= if (@mode in [:tags, :quick_tags]) && Enum.any?(@selection) do %>
-      <%= for {option, idx} <- Enum.with_index(@selection) do %>
-        <div class={class(@style, :tag, @tag_class, @tag_extra_class)}>
-          <%= if @tag == [] do %>
-            <%= option[:tag_label] || option[:label] %>
-          <% else %>
-            <%= render_slot(@tag, option) %>
-          <% end %>
-          <button
-            :if={!option[:sticky] && !@disabled}
-            type="button"
-            data-idx={idx}
-            class={
-              class(
-                @style,
-                :clear_tag_button,
-                @clear_tag_button_class,
-                @clear_tag_button_extra_class
-              ) ++
-                if @no_basic_styles_for_clear_buttons, do: [], else: ~w(ls-clear-tag-button)
-            }
-          >
-            <%= if @clear_button == [] do %>
-              <.x />
+  <%= if @tags_container_position == :top do %>
+    <div class={
+      class(@style, :tags_container, @tags_container_class, @tags_container_extra_class)
+    }>
+      <%= if (@mode in [:tags, :quick_tags]) && Enum.any?(@selection) do %>
+        <%= for {option, idx} <- Enum.with_index(@selection) do %>
+          <div class={class(@style, :tag, @tag_class, @tag_extra_class)}>
+            <%= if @tag == [] do %>
+              <%= option[:tag_label] || option[:label] %>
             <% else %>
-              <%= render_slot(@clear_button) %>
+              <%= render_slot(@tag, option) %>
             <% end %>
-          </button>
-        </div>
+            <button
+              :if={!option[:sticky] && !@disabled}
+              type="button"
+              data-idx={idx}
+              class={
+                class(
+                  @style,
+                  :clear_tag_button,
+                  @clear_tag_button_class,
+                  @clear_tag_button_extra_class
+                ) ++
+                  if @no_basic_styles_for_clear_buttons, do: [], else: ~w(ls-clear-tag-button)
+              }
+            >
+              <%= if @clear_button == [] do %>
+                <.x />
+              <% else %>
+                <%= render_slot(@clear_button) %>
+              <% end %>
+            </button>
+          </div>
+        <% end %>
       <% end %>
-    <% end %>
-  </div>
+    </div>
   <% end %>
 
   <div>
@@ -154,38 +156,40 @@
   <% end %>
 
   <%= if @tags_container_position == :bottom do %>
-  <div class={class(@style, :tags_container, @tags_container_class, @tags_container_extra_class)}>
-    <%= if (@mode in [:tags, :quick_tags]) && Enum.any?(@selection) do %>
-      <%= for {option, idx} <- Enum.with_index(@selection) do %>
-        <div class={class(@style, :tag, @tag_class, @tag_extra_class)}>
-          <%= if @tag == [] do %>
-            <%= option[:tag_label] || option[:label] %>
-          <% else %>
-            <%= render_slot(@tag, option) %>
-          <% end %>
-          <button
-            :if={!option[:sticky] && !@disabled}
-            type="button"
-            data-idx={idx}
-            class={
-              class(
-                @style,
-                :clear_tag_button,
-                @clear_tag_button_class,
-                @clear_tag_button_extra_class
-              ) ++
-                if @no_basic_styles_for_clear_buttons, do: [], else: ~w(ls-clear-tag-button)
-            }
-          >
-            <%= if @clear_button == [] do %>
-              <.x />
+    <div class={
+      class(@style, :tags_container, @tags_container_class, @tags_container_extra_class)
+    }>
+      <%= if (@mode in [:tags, :quick_tags]) && Enum.any?(@selection) do %>
+        <%= for {option, idx} <- Enum.with_index(@selection) do %>
+          <div class={class(@style, :tag, @tag_class, @tag_extra_class)}>
+            <%= if @tag == [] do %>
+              <%= option[:tag_label] || option[:label] %>
             <% else %>
-              <%= render_slot(@clear_button) %>
+              <%= render_slot(@tag, option) %>
             <% end %>
-          </button>
-        </div>
+            <button
+              :if={!option[:sticky] && !@disabled}
+              type="button"
+              data-idx={idx}
+              class={
+                class(
+                  @style,
+                  :clear_tag_button,
+                  @clear_tag_button_class,
+                  @clear_tag_button_extra_class
+                ) ++
+                  if @no_basic_styles_for_clear_buttons, do: [], else: ~w(ls-clear-tag-button)
+              }
+            >
+              <%= if @clear_button == [] do %>
+                <.x />
+              <% else %>
+                <%= render_slot(@clear_button) %>
+              <% end %>
+            </button>
+          </div>
+        <% end %>
       <% end %>
-    <% end %>
-  </div>
+    </div>
   <% end %>
 </div>

--- a/lib/live_select/component.html.heex
+++ b/lib/live_select/component.html.heex
@@ -8,6 +8,7 @@
   data-field={@field.id}
   data-debounce={@debounce}
 >
+<%= if @tags_container_position == :top do %>
   <div class={class(@style, :tags_container, @tags_container_class, @tags_container_extra_class)}>
     <%= if (@mode in [:tags, :quick_tags]) && Enum.any?(@selection) do %>
       <%= for {option, idx} <- Enum.with_index(@selection) do %>
@@ -41,6 +42,7 @@
       <% end %>
     <% end %>
   </div>
+  <% end %>
 
   <div>
     <%= text_input(@field.form, @text_input_field,
@@ -149,5 +151,41 @@
         </li>
       <% end %>
     </ul>
+  <% end %>
+
+  <%= if @tags_container_position == :bottom do %>
+  <div class={class(@style, :tags_container, @tags_container_class, @tags_container_extra_class)}>
+    <%= if (@mode in [:tags, :quick_tags]) && Enum.any?(@selection) do %>
+      <%= for {option, idx} <- Enum.with_index(@selection) do %>
+        <div class={class(@style, :tag, @tag_class, @tag_extra_class)}>
+          <%= if @tag == [] do %>
+            <%= option[:tag_label] || option[:label] %>
+          <% else %>
+            <%= render_slot(@tag, option) %>
+          <% end %>
+          <button
+            :if={!option[:sticky] && !@disabled}
+            type="button"
+            data-idx={idx}
+            class={
+              class(
+                @style,
+                :clear_tag_button,
+                @clear_tag_button_class,
+                @clear_tag_button_extra_class
+              ) ++
+                if @no_basic_styles_for_clear_buttons, do: [], else: ~w(ls-clear-tag-button)
+            }
+          >
+            <%= if @clear_button == [] do %>
+              <.x />
+            <% else %>
+              <%= render_slot(@clear_button) %>
+            <% end %>
+          </button>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
   <% end %>
 </div>


### PR DESCRIPTION
Adds tags_container_option option for user to choose whether the tags should be appear on the top or the bottom of the text field.

Keep legacy behaviour by defaulting to top position if not specified by the user.