### PR TITLE
Unify blur experience in single and multi modes

### DIFF
--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -199,15 +199,10 @@ defmodule LiveSelect.Component do
       |> client_select(%{
         parent_event: socket.assigns[:"phx-blur"],
         current_text:
-          cond do
-            socket.assigns.mode == :single && socket.assigns.selection != [] ->
-              List.first(socket.assigns.selection).label
-
-            socket.assigns.mode == :single && socket.assigns.selection == [] ->
-              ""
-
-            true ->
-              socket.assigns.current_text
+          if socket.assigns.mode == :single && socket.assigns.selection != [] do
+            List.first(socket.assigns.selection).label
+          else
+            ""
           end
       })
 


### PR DESCRIPTION
Currently blur behaves differently depending on mode, for single it hides user input if nothing was selected but it doesn't do the same for tags. 

This commit makes single with selection the only special case where we show something on blur (the selected label) .. otherwise just hide user input in all other cases.