### PR TITLE
Do not show <div> for tags when not in tag mode

### DIFF
--- a/lib/live_select/component.html.heex
+++ b/lib/live_select/component.html.heex
@@ -8,37 +8,38 @@
   data-field={@field.id}
   data-debounce={@debounce}
 >
-  <div class={class(@style, :tags_container, @tags_container_class, @tags_container_extra_class)}>
-    <%= if (@mode in [:tags, :quick_tags]) && Enum.any?(@selection) do %>
-      <%= for {option, idx} <- Enum.with_index(@selection) do %>
-        <div class={class(@style, :tag, @tag_class, @tag_extra_class)}>
-          <%= if @tag == [] do %>
-            <%= option[:tag_label] || option[:label] %>
+  <div
+    :if={@mode in [:tags, :quick_tags] && Enum.any?(@selection)}
+    class={class(@style, :tags_container, @tags_container_class, @tags_container_extra_class)}
+  >
+    <%= for {option, idx} <- Enum.with_index(@selection) do %>
+      <div class={class(@style, :tag, @tag_class, @tag_extra_class)}>
+        <%= if @tag == [] do %>
+          <%= option[:tag_label] || option[:label] %>
+        <% else %>
+          <%= render_slot(@tag, option) %>
+        <% end %>
+        <button
+          :if={!option[:sticky] && !@disabled}
+          type="button"
+          data-idx={idx}
+          class={
+            class(
+              @style,
+              :clear_tag_button,
+              @clear_tag_button_class,
+              @clear_tag_button_extra_class
+            ) ++
+              if @no_basic_styles_for_clear_buttons, do: [], else: ~w(ls-clear-tag-button)
+          }
+        >
+          <%= if @clear_button == [] do %>
+            <.x />
           <% else %>
-            <%= render_slot(@tag, option) %>
+            <%= render_slot(@clear_button) %>
           <% end %>
-          <button
-            :if={!option[:sticky] && !@disabled}
-            type="button"
-            data-idx={idx}
-            class={
-              class(
-                @style,
-                :clear_tag_button,
-                @clear_tag_button_class,
-                @clear_tag_button_extra_class
-              ) ++
-                if @no_basic_styles_for_clear_buttons, do: [], else: ~w(ls-clear-tag-button)
-            }
-          >
-            <%= if @clear_button == [] do %>
-              <.x />
-            <% else %>
-              <%= render_slot(@clear_button) %>
-            <% end %>
-          </button>
-        </div>
-      <% end %>
+        </button>
+      </div>
     <% end %>
   </div>
 


### PR DESCRIPTION
The container `<div>` for tags is shown even when not in tag mode. This creates some misalignments in forms (seen also in the showcase app, where the field is not properly aligned with the submit button - see below).

The diff seems complicated because of the different indentation, but the only change is that the `<%= if ... %>` block is now an `:if={...}` in the outer `<div>`.

<img width="744" height="151" alt="image" src="https://github.com/user-attachments/assets/02a92af8-b437-4a1a-8508-b794f7528308" />
