### PR TITLE
js: fix call to pushEventTo

### DIFF
--- a/assets/js/live_select.js
+++ b/assets/js/live_select.js
@@ -119,7 +119,7 @@ export default {
         },
         reconnected() {
             if (this.selection && this.selection.length > 0) {
-                this.pushEventTo(this.el.id, "selection_recovery", this.selection)
+                this.pushEventTo(this.el, "selection_recovery", this.selection)
             }
         }
     }


### PR DESCRIPTION
`this.el.id` would require a hash ("#"), but it's better to pass the DOM element since this is supported.

Fixes the following error in the web console on reconnect:
nothing found matching the phx-target selector "my_form_city_search_live_select_component"