### PR TITLE
fix: reject nil values in selection list

### DIFF
--- a/lib/live_select/component.ex
+++ b/lib/live_select/component.ex
@@ -486,6 +486,7 @@ defmodule LiveSelect.Component do
       else
         [selected]
       end
+      |> Enum.reject(&is_nil/1)
 
     socket =
       socket

--- a/test/live_select_test.exs
+++ b/test/live_select_test.exs
@@ -1106,4 +1106,23 @@ defmodule LiveSelectTest do
       assert_selected(live, "A")
     end
   end
+
+  test "handles nil in options list when navigating and clearing input", %{conn: conn} do
+    stub_options([{"A", 1}, {"B", 2}, {"C", 3}])
+
+    {:ok, live, _html} = live(conn, "/")
+
+    type(live, "ABC")
+
+    assert_options(live, ["A", "B", "C"])
+
+    keydown(live, "ArrowDown")
+    keydown(live, "Backspace")
+
+    type(live, "")
+
+    keydown(live, "Enter")
+
+    refute_selected(live)
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/maxmarcon/live_select/issues/125.

Hi.. thanks for the library, works great!

I started seeing this error here and there on our apps as well. So this is an attempt to fix it by rejecting nil values on the selection list. The added unit test reproduces the failure before the fix.